### PR TITLE
Remove redundant membership specs

### DIFF
--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -11,26 +11,10 @@ RSpec.describe Membership, type: :model do
     expect(membership.errors[:member]).to include("can't be the same as memberof")
   end
 
-  it "errors when the memberof's actortype is not has_members" do
-    member = FactoryBot.create(:actor)
-    memberof = FactoryBot.create(:actor, actortype: FactoryBot.create(:actortype, has_members: false))
-    membership = described_class.create(member: member, memberof: memberof)
-    expect(membership).to be_invalid
-    expect(membership.errors[:memberof]).to include("actortype can't have members")
-  end
-
   it "works when the memberof can have members" do
     member = FactoryBot.create(:actor)
     memberof = FactoryBot.create(:actor, actortype: FactoryBot.create(:actortype, :with_members))
     membership = described_class.create(member: member, memberof: memberof)
     expect(membership).to be_valid
-  end
-
-  it "errors when the member's actortype is also has_members" do
-    member = FactoryBot.create(:actor, actortype: FactoryBot.create(:actortype, :with_members))
-    memberof = FactoryBot.create(:actor, actortype: FactoryBot.create(:actortype, :with_members))
-    membership = described_class.create(member: member, memberof: memberof)
-    expect(membership).to be_invalid
-    expect(membership.errors[:member]).to include("can't also have members")
   end
 end


### PR DESCRIPTION
When two validation rules were removed in fc601cf51f5f5bd86b8928b0e24d92083bd082e3 this broke the specs.

This removes the specs that are no longer needed as the rules don't apply
anymore.