### PR TITLE
Add `private` column to indicators, defaulting to `false`

### DIFF
--- a/db/migrate/20220516081829_add_private_to_indicators.rb
+++ b/db/migrate/20220516081829_add_private_to_indicators.rb
@@ -1,0 +1,5 @@
+class AddPrivateToIndicators < ActiveRecord::Migration[6.1]
+  def change
+    add_column :indicators, :private, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_10_064811) do
+ActiveRecord::Schema.define(version: 2022_05_16_081829) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -181,6 +181,7 @@ ActiveRecord::Schema.define(version: 2022_02_10_064811) do
     t.string "reference"
     t.integer "updated_by_id"
     t.integer "created_by_id"
+    t.boolean "private", default: false
     t.index ["created_at"], name: "index_indicators_on_created_at"
     t.index ["draft"], name: "index_indicators_on_draft"
     t.index ["manager_id"], name: "index_indicators_on_manager_id"

--- a/spec/models/indicator_spec.rb
+++ b/spec/models/indicator_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Indicator, type: :model do
   it { is_expected.to have_many :recommendations }
   it { is_expected.to belong_to(:manager).optional }
 
+  it "is expected to default private to false" do
+    expect(subject.private).to eq(false)
+  end
+
   context "due_date field validations" do
     let!(:indicator_with_repeat) { FactoryBot.create(:indicator, :with_repeat) }
     let!(:indicator_without_repeat) { FactoryBot.create(:indicator, :without_repeat) }


### PR DESCRIPTION
We want to add the `private` column found in other tables to the
`indicators` table and default it to `false` like #26.

Closes #20.