### PR TITLE
Define user access for tables with `private` column

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,6 +1,7 @@
 class ApplicationPolicy
   def initialize(user, record)
     raise Pundit::NotAuthorizedError, "must be logged in" unless user
+
     @user = user
     @record = record
   end
@@ -27,15 +28,29 @@ class ApplicationPolicy
 
   class Scope
     attr_reader :user, :scope
+
     def resolve
-      return scope.all if @user.role?("admin") || @user.role?("manager")
-      if @user.role?("analyst")
-        if scope.column_names.include?("draft")
-          scope.where(draft: false)
-        else
-          scope.all
-        end
+      return scope.all if user.role?("admin")
+      return resolve_for_manager if user.role?("manager")
+      return resolve_for_analyst if user.role?("analyst")
+    end
+
+    def resolve_for_analyst
+      analyst_scope = scope.all
+      analyst_scope = analyst_scope.where(draft: false) if scope.column_names.include?("draft")
+      analyst_scope = analyst_scope.where(private: false) if scope.column_names.include?("private")
+
+      analyst_scope
+    end
+
+    def resolve_for_manager
+      manager_scope = scope.all
+      if scope.column_names.include?("private")
+        manager_scope = manager_scope
+          .where(private: false)
+          .or(manager_scope.where(created_by_id: user.id))
       end
+      manager_scope
     end
 
     def initialize(user, scope)

--- a/db/migrate/20220516080912_set_private_to_false_by_default.rb
+++ b/db/migrate/20220516080912_set_private_to_false_by_default.rb
@@ -1,0 +1,15 @@
+class SetPrivateToFalseByDefault < ActiveRecord::Migration[6.1]
+  TABLES = %i[actors categories measures pages resources]
+
+  def up
+    TABLES.each do |table|
+      change_column table, :private, :boolean, default: false
+    end
+  end
+
+  def down
+    TABLES.each do |table|
+      change_column table, :private, :boolean, default: true
+    end
+  end
+end

--- a/db/migrate/20220516081829_add_private_to_indicators.rb
+++ b/db/migrate/20220516081829_add_private_to_indicators.rb
@@ -1,0 +1,5 @@
+class AddPrivateToIndicators < ActiveRecord::Migration[6.1]
+  def change
+    add_column :indicators, :private, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_16_080912) do
+ActiveRecord::Schema.define(version: 2022_05_16_081829) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -181,6 +181,7 @@ ActiveRecord::Schema.define(version: 2022_05_16_080912) do
     t.string "reference"
     t.integer "updated_by_id"
     t.integer "created_by_id"
+    t.boolean "private", default: false
     t.index ["created_at"], name: "index_indicators_on_created_at"
     t.index ["draft"], name: "index_indicators_on_draft"
     t.index ["manager_id"], name: "index_indicators_on_manager_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_10_064811) do
+ActiveRecord::Schema.define(version: 2022_05_16_080912) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,7 +55,7 @@ ActiveRecord::Schema.define(version: 2022_02_10_064811) do
     t.string "url"
     t.decimal "population"
     t.decimal "gdp"
-    t.boolean "private", default: true
+    t.boolean "private", default: false
     t.boolean "draft", default: true
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -119,7 +119,7 @@ ActiveRecord::Schema.define(version: 2022_02_10_064811) do
     t.integer "parent_id"
     t.date "date"
     t.integer "created_by_id"
-    t.boolean "private", default: true
+    t.boolean "private", default: false
     t.index ["draft"], name: "index_categories_on_draft"
     t.index ["manager_id"], name: "index_categories_on_manager_id"
     t.index ["taxonomy_id"], name: "index_categories_on_taxonomy_id"
@@ -275,7 +275,7 @@ ActiveRecord::Schema.define(version: 2022_02_10_064811) do
     t.string "status_lbs_protocol"
     t.decimal "amount"
     t.string "amount_comment"
-    t.boolean "private", default: true
+    t.boolean "private", default: false
     t.index ["draft"], name: "index_measures_on_draft"
     t.index ["measuretype_id"], name: "index_measures_on_measuretype_id"
     t.index ["parent_id"], name: "index_measures_on_parent_id"
@@ -321,7 +321,7 @@ ActiveRecord::Schema.define(version: 2022_02_10_064811) do
     t.integer "order"
     t.integer "updated_by_id"
     t.integer "created_by_id"
-    t.boolean "private", default: true
+    t.boolean "private", default: false
     t.index ["draft"], name: "index_pages_on_draft"
     t.index ["private"], name: "index_pages_on_private"
   end
@@ -399,7 +399,7 @@ ActiveRecord::Schema.define(version: 2022_02_10_064811) do
     t.text "description"
     t.text "url"
     t.bigint "resourcetype_id", null: false
-    t.boolean "private", default: true
+    t.boolean "private", default: false
     t.boolean "draft", default: true
     t.datetime "publication_date"
     t.datetime "access_date"

--- a/spec/controllers/actors_controller_spec.rb
+++ b/spec/controllers/actors_controller_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 require "json"
 
 RSpec.describe ActorsController, type: :controller do
-  let(:admin) { FactoryBot.create(:user, :manager) }
+  let(:admin) { FactoryBot.create(:user, :admin) }
   let(:analyst) { FactoryBot.create(:user, :analyst) }
   let(:guest) { FactoryBot.create(:user) }
   let(:manager) { FactoryBot.create(:user, :manager) }

--- a/spec/controllers/actors_controller_spec.rb
+++ b/spec/controllers/actors_controller_spec.rb
@@ -11,8 +11,6 @@ RSpec.describe ActorsController, type: :controller do
 
   describe "Get index" do
     subject { get :index, format: :json }
-    let!(:actor) { FactoryBot.create(:actor, :not_draft) }
-    let!(:draft_actor) { FactoryBot.create(:actor) }
 
     context "when not signed in" do
       it { expect(subject).to be_forbidden }
@@ -24,23 +22,52 @@ RSpec.describe ActorsController, type: :controller do
         expect(subject).to be_forbidden
       end
 
-      it "admin will see draft actors" do
-        sign_in admin
-        json = JSON.parse(subject.body)
-        expect(json["data"].length).to eq(2)
+      context "draft" do
+        let!(:actor) { FactoryBot.create(:actor, :not_draft) }
+        let!(:draft_actor) { FactoryBot.create(:actor) }
+
+        it "admin will see draft actors" do
+          sign_in admin
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(2)
+        end
+
+        it "manager will see draft actors" do
+          sign_in manager
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(2)
+        end
+
+        it "analyst will not see draft actors" do
+          sign_in analyst
+
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(1)
+        end
       end
 
-      it "manager will see draft actors" do
-        sign_in manager
-        json = JSON.parse(subject.body)
-        expect(json["data"].length).to eq(2)
-      end
+      context "private" do
+        let!(:actor) { FactoryBot.create(:actor, :not_private) }
+        let!(:private_actor) { FactoryBot.create(:actor, :private) }
+        let!(:private_actor_by_manager) { FactoryBot.create(:actor, :private, created_by_id: manager.id) }
 
-      it "analyst will not see draft actors" do
-        sign_in analyst
+        it "admin will see" do
+          sign_in admin
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(3)
+        end
 
-        json = JSON.parse(subject.body)
-        expect(json["data"].length).to eq(1)
+        it "manager who created will see" do
+          sign_in manager
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(2)
+        end
+
+        it "manager who didn't create will not see" do
+          sign_in FactoryBot.create(:user, :manager)
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(1)
+        end
       end
     end
   end

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -66,10 +66,40 @@ RSpec.describe CategoriesController, type: :controller do
 
   describe "Get show" do
     let(:category) { FactoryBot.create(:category) }
-    subject { get :show, params: {id: category}, format: :json }
+    let(:private_category) { FactoryBot.create(:category, :private) }
+    let(:private_category_by_manager) { FactoryBot.create(:category, :private, created_by_id: manager.id) }
+    let(:requested_resource) { category }
+
+    subject { get :show, params: {id: requested_resource}, format: :json }
 
     context "when not signed in" do
       it { expect(subject).to be_forbidden }
+    end
+
+    context "when signed in" do
+      context "as admin" do
+        before { sign_in admin }
+
+        it { expect(subject).to be_ok }
+      end
+
+      context "as manager" do
+        before { sign_in manager }
+
+        it { expect(subject).to be_ok }
+
+        context "who created will see" do
+          let(:requested_resource) { private_category_by_manager }
+
+          it { expect(subject).to be_ok }
+        end
+
+        context "who didn't create won't see" do
+          let(:requested_resource) { private_category }
+
+          it { expect(subject).to be_not_found }
+        end
+      end
     end
   end
 

--- a/spec/controllers/indicators_controller_spec.rb
+++ b/spec/controllers/indicators_controller_spec.rb
@@ -4,28 +4,39 @@ require "rails_helper"
 require "json"
 
 RSpec.describe IndicatorsController, type: :controller do
+  let(:admin) { FactoryBot.create(:user, :admin) }
+  let(:analyst) { FactoryBot.create(:user, :analyst) }
+  let(:guest) { FactoryBot.create(:user) }
+  let(:manager) { FactoryBot.create(:user, :manager) }
+
   describe "Get index" do
     subject { get :index, format: :json }
     let!(:indicator) { FactoryBot.create(:indicator) }
-    let!(:draft_indicator) { FactoryBot.create(:indicator, draft: true) }
 
     context "when not signed in" do
       it { expect(subject).to be_forbidden }
     end
 
     context "when signed in" do
-      let(:guest) { FactoryBot.create(:user) }
-      let(:user) { FactoryBot.create(:user, :manager) }
-
       it "guest will be forbidden" do
         sign_in guest
         expect(subject).to be_forbidden
       end
 
-      it "manager will see draft indicators" do
-        sign_in user
-        json = JSON.parse(subject.body)
-        expect(json["data"].length).to eq(2)
+      context "draft" do
+        let!(:draft_indicator) { FactoryBot.create(:indicator, draft: true) }
+
+        it "admin will see draft indicators" do
+          sign_in admin
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(2)
+        end
+
+        it "manager will see draft indicators" do
+          sign_in manager
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(2)
+        end
       end
     end
 
@@ -34,10 +45,8 @@ RSpec.describe IndicatorsController, type: :controller do
       let(:indicator_different_measure) { FactoryBot.create(:indicator) }
 
       context "when signed in" do
-        let(:user) { FactoryBot.create(:user, :manager) }
-
         it "filters from measures" do
-          sign_in user
+          sign_in manager
           indicator_different_measure.measures << measure
           subject = get :index, params: {measure_id: measure.id}, format: :json
           json = JSON.parse(subject.body)
@@ -67,8 +76,6 @@ RSpec.describe IndicatorsController, type: :controller do
     end
 
     context "when signed in" do
-      let(:guest) { FactoryBot.create(:user) }
-      let(:user) { FactoryBot.create(:user, :manager) }
       let(:measure) { FactoryBot.create(:measure) }
       subject do
         post :create,
@@ -88,19 +95,19 @@ RSpec.describe IndicatorsController, type: :controller do
       end
 
       it "will allow a manager to create a indicator" do
-        sign_in user
+        sign_in manager
         expect(subject).to be_created
       end
 
       it "will record what manager created the indicator", versioning: true do
         expect(PaperTrail).to be_enabled
-        sign_in user
+        sign_in manager
         json = JSON.parse(subject.body)
-        expect(json["data"]["attributes"]["updated_by_id"].to_i).to eq user.id
+        expect(json["data"]["attributes"]["updated_by_id"].to_i).to eq manager.id
       end
 
       it "will return an error if params are incorrect" do
-        sign_in user
+        sign_in manager
         post :create, format: :json, params: {indicator: {description: "desc only"}}
         expect(response).to have_http_status(422)
       end
@@ -123,22 +130,18 @@ RSpec.describe IndicatorsController, type: :controller do
     end
 
     context "when user signed in" do
-      let(:admin) { FactoryBot.create(:user, :admin) }
-      let(:guest) { FactoryBot.create(:user) }
-      let(:user) { FactoryBot.create(:user, :manager) }
-
       it "will not allow a guest to update a indicator" do
         sign_in guest
         expect(subject).to be_forbidden
       end
 
       it "will allow a manager to update a indicator" do
-        sign_in user
+        sign_in manager
         expect(subject).to be_ok
       end
 
       it "will reject an update where the last_updated_at is older than updated_at in the database" do
-        sign_in user
+        sign_in manager
         indicator_get = get :show, params: {id: indicator}, format: :json
         json = JSON.parse(indicator_get.body)
         current_update_at = json["data"]["attributes"]["updated_at"]
@@ -161,21 +164,21 @@ RSpec.describe IndicatorsController, type: :controller do
 
       it "will record what manager updated the indicator", versioning: true do
         expect(PaperTrail).to be_enabled
-        sign_in user
+        sign_in manager
         json = JSON.parse(subject.body)
-        expect(json["data"]["attributes"]["updated_by_id"].to_i).to eq user.id
+        expect(json["data"]["attributes"]["updated_by_id"].to_i).to eq manager.id
       end
 
       it "will return the latest updated_by", versioning: true do
         expect(PaperTrail).to be_enabled
         indicator.versions.first.update_column(:whodunnit, admin.id)
-        sign_in user
+        sign_in manager
         json = JSON.parse(subject.body)
-        expect(json["data"]["attributes"]["updated_by_id"].to_i).to eq(user.id)
+        expect(json["data"]["attributes"]["updated_by_id"].to_i).to eq(manager.id)
       end
 
       it "will return an error if params are incorrect" do
-        sign_in user
+        sign_in manager
         put :update, format: :json, params: {id: indicator, indicator: {title: ""}}
         expect(response).to have_http_status(422)
       end
@@ -193,16 +196,13 @@ RSpec.describe IndicatorsController, type: :controller do
     end
 
     context "when user signed in" do
-      let(:guest) { FactoryBot.create(:user) }
-      let(:user) { FactoryBot.create(:user, :manager) }
-
       it "will not allow a guest to delete a indicator" do
         sign_in guest
         expect(subject).to be_forbidden
       end
 
       it "will allow a manager to delete a indicator" do
-        sign_in user
+        sign_in manager
         expect(subject).to be_no_content
       end
     end

--- a/spec/controllers/measures_controller_spec.rb
+++ b/spec/controllers/measures_controller_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 require "json"
 
 RSpec.describe MeasuresController, type: :controller do
-  let(:admin) { FactoryBot.create(:user, :manager) }
+  let(:admin) { FactoryBot.create(:user, :admin) }
   let(:analyst) { FactoryBot.create(:user, :analyst) }
   let(:guest) { FactoryBot.create(:user) }
   let(:manager) { FactoryBot.create(:user, :manager) }

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -73,19 +73,49 @@ RSpec.describe PagesController, type: :controller do
     end
 
     context "when signed in" do
+      let(:private_page_by_manager) { FactoryBot.create(:page, :private, created_by_id: manager.id) }
+      let(:private_page) { FactoryBot.create(:page, :private) }
+      let(:requested_resource) { page }
+      subject { get :show, params: {id: requested_resource}, format: :json }
+
       context "as analyst" do
         context "will show page" do
-          subject { get :show, params: {id: page}, format: :json }
+          let(:requested_resource) { page }
           before { sign_in analyst }
 
           it { expect(subject).to be_ok }
         end
 
         context "will not show draft page" do
-          subject { get :show, params: {id: draft_page}, format: :json }
+          let(:requested_resource) { draft_page }
+
           before { sign_in analyst }
 
           it { expect(subject).to be_not_found }
+        end
+
+        context "as admin" do
+          before { sign_in admin }
+
+          it { expect(subject).to be_ok }
+        end
+
+        context "as manager" do
+          before { sign_in manager }
+
+          it { expect(subject).to be_ok }
+
+          context "who created will see" do
+            let(:requested_resource) { private_page_by_manager }
+
+            it { expect(subject).to be_ok }
+          end
+
+          context "who didn't create won't see" do
+            let(:requested_resource) { private_page }
+
+            it { expect(subject).to be_not_found }
+          end
         end
       end
     end

--- a/spec/factories/actors.rb
+++ b/spec/factories/actors.rb
@@ -17,5 +17,9 @@ FactoryBot.define do
     trait :not_private do
       private { false }
     end
+
+    trait :private do
+      private { true }
+    end
   end
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -13,5 +13,13 @@ FactoryBot.define do
     trait :sub_category do
       title { "sub" }
     end
+
+    trait :not_private do
+      private { false }
+    end
+
+    trait :private do
+      private { true }
+    end
   end
 end

--- a/spec/factories/indicators.rb
+++ b/spec/factories/indicators.rb
@@ -31,5 +31,13 @@ FactoryBot.define do
     trait :with_manager do
       manager { create(:user) }
     end
+
+    trait :not_private do
+      private { false }
+    end
+
+    trait :private do
+      private { true }
+    end
   end
 end

--- a/spec/factories/measures.rb
+++ b/spec/factories/measures.rb
@@ -12,5 +12,13 @@ FactoryBot.define do
     trait :without_category do
       categories { [] }
     end
+
+    trait :not_private do
+      private { false }
+    end
+
+    trait :private do
+      private { true }
+    end
   end
 end

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -4,5 +4,13 @@ FactoryBot.define do
     content { "MyText" }
     menu_title { "MyString" }
     draft { false }
+
+    trait :not_private do
+      private { false }
+    end
+
+    trait :private do
+      private { true }
+    end
   end
 end

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -4,10 +4,17 @@ FactoryBot.define do
     association(:resourcetype)
     description { Faker::Movies::StarWars.quote }
     draft { false }
-    private { true }
     publication_date { Date.today }
     status { Faker::Creature::Cat.registry }
     title { "MyString" }
     url { "https://impactoss.org" }
+
+    trait :not_private do
+      private { false }
+    end
+
+    trait :private do
+      private { true }
+    end
   end
 end

--- a/spec/models/actor_spec.rb
+++ b/spec/models/actor_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Actor, type: :model do
   it { is_expected.to validate_presence_of :title }
   it { is_expected.to belong_to :actortype }
 
-  it "is expected to default private to true" do
-    expect(subject.private).to eq(true)
+  it "is expected to default private to false" do
+    expect(subject.private).to eq(false)
   end
 
   it "is expected to default draft to true" do

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe Category, type: :model do
   it { is_expected.to have_many :categories }
   it { is_expected.to have_many :children_due_dates }
 
+  it "is expected to default private to false" do
+    expect(subject.private).to eq(false)
+  end
+
   context "Sub-relation validations" do
     it "Should update parent_id with correct taxonomy relation" do
       category = FactoryBot.create(:category, :parent_category)

--- a/spec/models/indicator_spec.rb
+++ b/spec/models/indicator_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Indicator, type: :model do
   it { is_expected.to have_many :recommendations }
   it { is_expected.to belong_to(:manager).optional }
 
+  it "is expected to default private to false" do
+    expect(subject.private).to eq(false)
+  end
+
   context "due_date field validations" do
     let!(:indicator_with_repeat) { FactoryBot.create(:indicator, :with_repeat) }
     let!(:indicator_without_repeat) { FactoryBot.create(:indicator, :without_repeat) }

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Measure, type: :model do
   it { is_expected.to have_many :due_dates }
   it { is_expected.to have_many :progress_reports }
 
+  it "is expected to default private to false" do
+    expect(subject.private).to eq(false)
+  end
+
   context "parent_id" do
     subject do
       described_class.create(

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -2,4 +2,8 @@ require "rails_helper"
 
 RSpec.describe Page, type: :model do
   it { is_expected.to validate_presence_of :title }
+
+  it "is expected to default private to false" do
+    expect(subject.private).to eq(false)
+  end
 end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -3,4 +3,8 @@ require "rails_helper"
 RSpec.describe Resource, type: :model do
   it { is_expected.to validate_presence_of :title }
   it { is_expected.to belong_to :resourcetype }
+
+  it "is expected to default private to false" do
+    expect(subject.private).to eq(false)
+  end
 end


### PR DESCRIPTION
We want to have granular user permissions for tables with a `private`
column, per #19.

This just implements the `private` rules, and `is_archive` will come
in a future change.

Relies on #26 and #27, and this PR includes their commits.