### PR TITLE
Update email address in tests

### DIFF
--- a/spec/mailers/due_date_mailer_spec.rb
+++ b/spec/mailers/due_date_mailer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DueDateMailer, type: :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t("due_date_mailer.due.subject"))
       expect(mail.to).to eq([manager.email])
-      expect(mail.from).to eq(["no-reply@dumpark.com"])
+      expect(mail.from).to eq(["plasticpolicy@wwf.no"])
     end
 
     it "mentions the managers name" do
@@ -29,7 +29,7 @@ RSpec.describe DueDateMailer, type: :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t("due_date_mailer.overdue.subject"))
       expect(mail.to).to eq([manager.email])
-      expect(mail.from).to eq(["no-reply@dumpark.com"])
+      expect(mail.from).to eq(["plasticpolicy@wwf.no"])
     end
 
     it "mentions the managers name" do
@@ -50,7 +50,7 @@ RSpec.describe DueDateMailer, type: :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t("due_date_mailer.category_due.subject"))
       expect(mail.to).to eq([manager.email])
-      expect(mail.from).to eq(["no-reply@dumpark.com"])
+      expect(mail.from).to eq(["plasticpolicy@wwf.no"])
     end
 
     it "mentions the managers name" do
@@ -71,7 +71,7 @@ RSpec.describe DueDateMailer, type: :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t("due_date_mailer.category_overdue.subject"))
       expect(mail.to).to eq([manager.email])
-      expect(mail.from).to eq(["no-reply@dumpark.com"])
+      expect(mail.from).to eq(["plasticpolicy@wwf.no"])
     end
 
     it "mentions the managers name" do

--- a/spec/mailers/due_date_mailer_spec.rb
+++ b/spec/mailers/due_date_mailer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DueDateMailer, type: :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t("due_date_mailer.due.subject"))
       expect(mail.to).to eq([manager.email])
-      expect(mail.from).to eq(["no-reply@mail.impactoss.org"])
+      expect(mail.from).to eq(["no-reply@dumpark.com"])
     end
 
     it "mentions the managers name" do
@@ -29,7 +29,7 @@ RSpec.describe DueDateMailer, type: :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t("due_date_mailer.overdue.subject"))
       expect(mail.to).to eq([manager.email])
-      expect(mail.from).to eq(["no-reply@mail.impactoss.org"])
+      expect(mail.from).to eq(["no-reply@dumpark.com"])
     end
 
     it "mentions the managers name" do
@@ -50,7 +50,7 @@ RSpec.describe DueDateMailer, type: :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t("due_date_mailer.category_due.subject"))
       expect(mail.to).to eq([manager.email])
-      expect(mail.from).to eq(["no-reply@mail.impactoss.org"])
+      expect(mail.from).to eq(["no-reply@dumpark.com"])
     end
 
     it "mentions the managers name" do
@@ -71,7 +71,7 @@ RSpec.describe DueDateMailer, type: :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t("due_date_mailer.category_overdue.subject"))
       expect(mail.to).to eq([manager.email])
-      expect(mail.from).to eq(["no-reply@mail.impactoss.org"])
+      expect(mail.from).to eq(["no-reply@dumpark.com"])
     end
 
     it "mentions the managers name" do


### PR DESCRIPTION
The tests are failing because 2582a973 updated the mailer from address
but it was expecting another one.

This was updated again in dc877814e0.