### PR TITLE
Add `is_archive` policy and specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,5 +63,4 @@ group :test do
   gem "timecop"
 end
 
-
 gem "puma", "~> 5.5"

--- a/app/policies/actor_policy.rb
+++ b/app/policies/actor_policy.rb
@@ -19,7 +19,7 @@ class ActorPolicy < ApplicationPolicy
       :private,
       :title,
       :url,
-      :is_archive
-    ]
+      (:is_archive if @user.role?("admin"))
+    ].compact
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -38,6 +38,7 @@ class ApplicationPolicy
     def resolve_for_analyst
       analyst_scope = scope.all
       analyst_scope = analyst_scope.where(draft: false) if scope.column_names.include?("draft")
+      analyst_scope = analyst_scope.where(is_archive: false) if scope.column_names.include?("is_archive")
       analyst_scope = analyst_scope.where(private: false) if scope.column_names.include?("private")
 
       analyst_scope
@@ -50,6 +51,7 @@ class ApplicationPolicy
           .where(private: false)
           .or(manager_scope.where(created_by_id: user.id))
       end
+      manager_scope = manager_scope.where(is_archive: false) if scope.column_names.include?("is_archive")
       manager_scope
     end
 

--- a/app/policies/category_policy.rb
+++ b/app/policies/category_policy.rb
@@ -18,6 +18,5 @@ class CategoryPolicy < ApplicationPolicy
       :is_archive,
       :private
     ]
-
   end
 end

--- a/app/policies/category_policy.rb
+++ b/app/policies/category_policy.rb
@@ -15,8 +15,8 @@ class CategoryPolicy < ApplicationPolicy
       :reference,
       :date,
       :user_only,
-      :is_archive,
+      (:is_archive if @user.role?("admin")),
       :private
-    ]
+    ].compact
   end
 end

--- a/app/policies/indicator_policy.rb
+++ b/app/policies/indicator_policy.rb
@@ -2,7 +2,8 @@
 
 class IndicatorPolicy < ApplicationPolicy
   def permitted_attributes
-    [:title,
+    [
+      :title,
       :description,
       :draft,
       :manager_id,
@@ -12,8 +13,11 @@ class IndicatorPolicy < ApplicationPolicy
       :end_date,
       :reference,
       :private,
-      :is_archive,
-      measure_indicators_attributes: [:measure_id,
-        measure_attributes: [:id, :title, :description, :target_date, :draft]]]
+      (:is_archive if @user.role?("admin")),
+      measure_indicators_attributes: [
+        :measure_id,
+        measure_attributes: [:id, :title, :description, :target_date, :draft]
+      ]
+    ].compact
   end
 end

--- a/app/policies/measure_policy.rb
+++ b/app/policies/measure_policy.rb
@@ -27,7 +27,7 @@ class MeasurePolicy < ApplicationPolicy
       :target_date,
       :title,
       :url,
-      :is_archive,
+      (:is_archive if @user.role?("admin")),
       measure_categories_attributes: [
         :category_id,
         category_attributes: [
@@ -50,6 +50,6 @@ class MeasurePolicy < ApplicationPolicy
           :title
         ]
       ]
-    ]
+    ].compact
   end
 end

--- a/app/policies/resource_policy.rb
+++ b/app/policies/resource_policy.rb
@@ -10,7 +10,7 @@ class ResourcePolicy < ApplicationPolicy
       :title,
       :resourcetype_id,
       :url,
-      :is_archive
-    ]
+      (:is_archive if @user.role?("admin"))
+    ].compact
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -230,7 +230,6 @@ class Seeds
     countrystatus.categories.create!(title: "Disputed")
     countrystatus.categories.create!(title: "Indeterminate")
     countrystatus.categories.create!(title: "Sovereign country")
-
   end
 
   def development_seeds!

--- a/spec/controllers/actors_controller_spec.rb
+++ b/spec/controllers/actors_controller_spec.rb
@@ -148,20 +148,18 @@ RSpec.describe ActorsController, type: :controller do
       let(:recommendation) { FactoryBot.create(:recommendation) }
       let(:category) { FactoryBot.create(:category) }
       let(:actortype) { FactoryBot.create(:actortype) }
-
-      subject do
-        post :create,
-          format: :json,
-          params: {
-            actor: {
-              code: "test",
-              title: "test",
-              description: "test",
-              actortype_id: actortype.id,
-              target_date: "today"
-            }
+      let(:params) do
+        {
+          actor: {
+            code: "test",
+            title: "test",
+            description: "test",
+            actortype_id: actortype.id,
+            target_date: "today"
           }
+        }
       end
+      subject { post :create, format: :json, params: params }
 
       it "will not allow a guest to create an actor" do
         sign_in guest
@@ -181,6 +179,33 @@ RSpec.describe ActorsController, type: :controller do
       it "will allow an admin to create an actor" do
         sign_in admin
         expect(subject).to be_created
+      end
+
+      context "is_archive" do
+        let(:params) do
+          {
+            actor: {
+              code: "test",
+              title: "test",
+              description: "test",
+              actortype_id: actortype.id,
+              target_date: "today",
+              is_archive: true
+            }
+          }
+        end
+
+        it "can't be set by manager" do
+          sign_in manager
+          expect(subject).to be_created
+          expect(JSON.parse(subject.body).dig("data", "attributes", "is_archive")).to eq false
+        end
+
+        it "can be set by admin" do
+          sign_in admin
+          expect(subject).to be_created
+          expect(JSON.parse(subject.body).dig("data", "attributes", "is_archive")).to eq true
+        end
       end
 
       it "will record what manager created the actor", versioning: true do
@@ -232,6 +257,22 @@ RSpec.describe ActorsController, type: :controller do
       it "will allow an admin to update an actor" do
         sign_in admin
         expect(subject).to be_ok
+      end
+
+      context "is_archive" do
+        subject do
+          put :update, format: :json, params: {id: actor, actor: {is_archive: true}}
+        end
+
+        it "can't be set by manager" do
+          sign_in manager
+          expect(JSON.parse(subject.body).dig("data", "attributes", "is_archive")).to eq false
+        end
+
+        it "can be set by admin" do
+          sign_in admin
+          expect(JSON.parse(subject.body).dig("data", "attributes", "is_archive")).to eq true
+        end
       end
 
       it "will reject and update where the last_updated_at is older than updated_at in the database" do

--- a/spec/controllers/actors_controller_spec.rb
+++ b/spec/controllers/actors_controller_spec.rb
@@ -46,6 +46,30 @@ RSpec.describe ActorsController, type: :controller do
         end
       end
 
+      context "is_archive actors" do
+        let!(:actor) { FactoryBot.create(:actor, :not_is_archive) }
+        let!(:is_archive_actor) { FactoryBot.create(:actor, :is_archive) }
+
+        it "admin will see" do
+          sign_in admin
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(2)
+        end
+
+        it "manager will not see" do
+          sign_in manager
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(1)
+        end
+
+        it "analyst will not see" do
+          sign_in analyst
+
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(0)
+        end
+      end
+
       context "private" do
         let!(:actor) { FactoryBot.create(:actor, :not_private) }
         let!(:private_actor) { FactoryBot.create(:actor, :private) }

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -38,6 +38,30 @@ RSpec.describe CategoriesController, type: :controller do
         end
       end
 
+      context "is_archive categories" do
+        let!(:category) { FactoryBot.create(:category, :not_is_archive) }
+        let!(:is_archive_category) { FactoryBot.create(:category, :is_archive) }
+
+        it "admin will see" do
+          sign_in admin
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(2)
+        end
+
+        it "manager will not see" do
+          sign_in manager
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(1)
+        end
+
+        it "analyst will not see" do
+          sign_in analyst
+
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(1)
+        end
+      end
+
       context "private" do
         let!(:category) { FactoryBot.create(:category, :not_private) }
         let!(:private_category) { FactoryBot.create(:category, :private) }

--- a/spec/controllers/indicators_controller_spec.rb
+++ b/spec/controllers/indicators_controller_spec.rb
@@ -38,6 +38,30 @@ RSpec.describe IndicatorsController, type: :controller do
           expect(json["data"].length).to eq(2)
         end
       end
+
+      context "is_archive indicators" do
+        let!(:indicator) { FactoryBot.create(:indicator, :not_is_archive) }
+        let!(:is_archive_indicator) { FactoryBot.create(:indicator, :is_archive) }
+
+        it "admin will see" do
+          sign_in admin
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(2)
+        end
+
+        it "manager will not see" do
+          sign_in manager
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(1)
+        end
+
+        it "analyst will not see" do
+          sign_in analyst
+
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(1)
+        end
+      end
     end
 
     context "filters" do

--- a/spec/controllers/measures_controller_spec.rb
+++ b/spec/controllers/measures_controller_spec.rb
@@ -46,6 +46,30 @@ RSpec.describe MeasuresController, type: :controller do
         end
       end
 
+      context "is_archive measures" do
+        let!(:measure) { FactoryBot.create(:measure, :not_is_archive) }
+        let!(:is_archive_measure) { FactoryBot.create(:measure, :is_archive) }
+
+        it "admin will see" do
+          sign_in admin
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(2)
+        end
+
+        it "manager will not see" do
+          sign_in manager
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(1)
+        end
+
+        it "analyst will not see" do
+          sign_in analyst
+
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(1)
+        end
+      end
+
       context "private" do
         let!(:measure) { FactoryBot.create(:measure, :not_private) }
         let!(:private_measure) { FactoryBot.create(:measure, :private) }

--- a/spec/controllers/measures_controller_spec.rb
+++ b/spec/controllers/measures_controller_spec.rb
@@ -189,30 +189,30 @@ RSpec.describe MeasuresController, type: :controller do
       let(:recommendation) { FactoryBot.create(:recommendation) }
       let(:category) { FactoryBot.create(:category) }
       let(:measuretype) { FactoryBot.create(:measuretype) }
-
-      subject do
-        post :create,
-          format: :json,
-          params: {
-            measure: {
-              title: "test",
-              description: "test",
-              measuretype_id: measuretype.id,
-              target_date: "today"
-            }
+      let(:params) do
+        {
+          measure: {
+            title: "test",
+            description: "test",
+            measuretype_id: measuretype.id,
+            target_date: "today"
           }
-        # This is an example creating a new recommendation record in the post
-        # post :create,
-        #      format: :json,
-        #      params: {
-        #        measure: {
-        #          title: 'test',
-        #          description: 'test',
-        #          target_date: 'today',
-        #          recommendation_measures_attributes: [ { recommendation_attributes: { title: 'test 1', number: 1 } } ]
-        #        }
-        #      }
+        }
       end
+
+      subject { post :create, format: :json, params: params }
+
+      # This is an example creating a new recommendation record in the post
+      # post :create,
+      #      format: :json,
+      #      params: {
+      #        measure: {
+      #          title: 'test',
+      #          description: 'test',
+      #          target_date: 'today',
+      #          recommendation_measures_attributes: [ { recommendation_attributes: { title: 'test 1', number: 1 } } ]
+      #        }
+      #      }
 
       it "will not allow a guest to create a measure" do
         sign_in guest
@@ -232,6 +232,32 @@ RSpec.describe MeasuresController, type: :controller do
       it "will allow an admin to create a measure" do
         sign_in admin
         expect(subject).to be_created
+      end
+
+      context "is_archive" do
+        let(:params) do
+          {
+            measure: {
+              title: "test",
+              description: "test",
+              measuretype_id: measuretype.id,
+              target_date: "today",
+              is_archive: true
+            }
+          }
+        end
+
+        it "can't be set by manager" do
+          sign_in manager
+          expect(subject).to be_created
+          expect(JSON.parse(subject.body).dig("data", "attributes", "is_archive")).to eq false
+        end
+
+        it "can be set by admin" do
+          sign_in admin
+          expect(subject).to be_created
+          expect(JSON.parse(subject.body).dig("data", "attributes", "is_archive")).to eq true
+        end
       end
 
       it "will record what manager created the measure", versioning: true do
@@ -283,6 +309,22 @@ RSpec.describe MeasuresController, type: :controller do
       it "will allow an admin to update a measure" do
         sign_in admin
         expect(subject).to be_ok
+      end
+
+      context "is_archive" do
+        subject do
+          put :update, format: :json, params: {id: measure, measure: {is_archive: true}}
+        end
+
+        it "can't be set by manager" do
+          sign_in manager
+          expect(JSON.parse(subject.body).dig("data", "attributes", "is_archive")).to eq false
+        end
+
+        it "can be set by admin" do
+          sign_in admin
+          expect(JSON.parse(subject.body).dig("data", "attributes", "is_archive")).to eq true
+        end
       end
 
       it "will reject and update where the last_updated_at is older than updated_at in the database" do

--- a/spec/controllers/resources_controller_spec.rb
+++ b/spec/controllers/resources_controller_spec.rb
@@ -38,6 +38,30 @@ RSpec.describe ResourcesController, type: :controller do
         end
       end
 
+      context "is_archive resources" do
+        let!(:resource) { FactoryBot.create(:resource, :not_is_archive) }
+        let!(:is_archive_resource) { FactoryBot.create(:resource, :is_archive) }
+
+        it "admin will see" do
+          sign_in admin
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(2)
+        end
+
+        it "manager will not see" do
+          sign_in manager
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(1)
+        end
+
+        it "analyst will not see" do
+          sign_in analyst
+
+          json = JSON.parse(subject.body)
+          expect(json["data"].length).to eq(1)
+        end
+      end
+
       context "private" do
         let!(:resource) { FactoryBot.create(:resource, :not_private) }
         let!(:private_resource) { FactoryBot.create(:resource, :private) }

--- a/spec/controllers/resources_controller_spec.rb
+++ b/spec/controllers/resources_controller_spec.rb
@@ -165,17 +165,16 @@ RSpec.describe ResourcesController, type: :controller do
     context "when signed in" do
       let(:taxonomy) { FactoryBot.create(:taxonomy) }
       let(:resourcetype) { FactoryBot.create(:resourcetype) }
-
-      subject do
-        post :create,
-          format: :json,
-          params: {
-            resource: {
-              title: "test",
-              resourcetype_id: resourcetype.id
-            }
+      let(:params) do
+        {
+          resource: {
+            title: "test",
+            resourcetype_id: resourcetype.id
           }
+        }
       end
+
+      subject { post :create, format: :json, params: params }
 
       it "will not allow a guest to create a resource" do
         sign_in guest
@@ -192,9 +191,33 @@ RSpec.describe ResourcesController, type: :controller do
         expect(subject).to be_created
       end
 
-      it "will not allow an admin to create a resource" do
+      it "will allow an admin to create a resource" do
         sign_in admin
         expect(subject).to be_created
+      end
+
+      context "is_archive" do
+        let(:params) do
+          {
+            resource: {
+              title: "test",
+              resourcetype_id: resourcetype.id,
+              is_archive: true
+            }
+          }
+        end
+
+        it "can't be set by manager" do
+          sign_in manager
+          expect(subject).to be_created
+          expect(JSON.parse(subject.body).dig("data", "attributes", "is_archive")).to eq false
+        end
+
+        it "can be set by admin" do
+          sign_in admin
+          expect(subject).to be_created
+          expect(JSON.parse(subject.body).dig("data", "attributes", "is_archive")).to eq true
+        end
       end
 
       it "will record which admin created the resource", versioning: true do
@@ -241,6 +264,22 @@ RSpec.describe ResourcesController, type: :controller do
       it "will allow an admin to update a resource" do
         sign_in admin
         expect(subject).to be_ok
+      end
+
+      context "is_archive" do
+        subject do
+          put :update, format: :json, params: {id: resource, resource: {is_archive: true}}
+        end
+
+        it "can't be set by manager" do
+          sign_in manager
+          expect(JSON.parse(subject.body).dig("data", "attributes", "is_archive")).to eq false
+        end
+
+        it "can be set by admin" do
+          sign_in admin
+          expect(JSON.parse(subject.body).dig("data", "attributes", "is_archive")).to eq true
+        end
       end
 
       it "will reject and update where the last_updated_at is older than updated_at in the database" do

--- a/spec/factories/actors.rb
+++ b/spec/factories/actors.rb
@@ -10,8 +10,20 @@ FactoryBot.define do
     prefix { Faker::Name.prefix }
     title { Faker::Creature::Cat.registry }
 
+    trait :draft do
+      draft { true }
+    end
+
     trait :not_draft do
       draft { false }
+    end
+
+    trait :is_archive do
+      is_archive { true }
+    end
+
+    trait :not_is_archive do
+      is_archive { false }
     end
 
     trait :not_private do

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -14,6 +14,14 @@ FactoryBot.define do
       title { "sub" }
     end
 
+    trait :is_archive do
+      is_archive { true }
+    end
+
+    trait :not_is_archive do
+      is_archive { false }
+    end
+
     trait :not_private do
       private { false }
     end

--- a/spec/factories/indicators.rb
+++ b/spec/factories/indicators.rb
@@ -32,6 +32,14 @@ FactoryBot.define do
       manager { create(:user) }
     end
 
+    trait :is_archive do
+      is_archive { true }
+    end
+
+    trait :not_is_archive do
+      is_archive { false }
+    end
+
     trait :not_private do
       private { false }
     end

--- a/spec/factories/measures.rb
+++ b/spec/factories/measures.rb
@@ -13,6 +13,14 @@ FactoryBot.define do
       categories { [] }
     end
 
+    trait :is_archive do
+      is_archive { true }
+    end
+
+    trait :not_is_archive do
+      is_archive { false }
+    end
+
     trait :not_private do
       private { false }
     end

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -9,6 +9,14 @@ FactoryBot.define do
     title { "MyString" }
     url { "https://impactoss.org" }
 
+    trait :is_archive do
+      is_archive { true }
+    end
+
+    trait :not_is_archive do
+      is_archive { false }
+    end
+
     trait :not_private do
       private { false }
     end


### PR DESCRIPTION
We want to make sure that only admin users can set `is_archive`, and that
only admin users can see things that are marked `is_archive`.

Closes #19