### PR TITLE
Cascade delete associated relationships

### DIFF
--- a/app/models/actor.rb
+++ b/app/models/actor.rb
@@ -18,6 +18,9 @@ class Actor < VersionedRecord
   has_many :measure_actors, dependent: :destroy
   has_many :passive_measures, through: :measure_actors
 
+  has_many :user_actors, dependent: :destroy
+  has_many :users, through: :user_actors
+
   validates :title, presence: true
   validate :different_parent, :not_own_descendant
 

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -11,11 +11,21 @@ class Measure < VersionedRecord
   has_many :measure_actors, dependent: :destroy
   has_many :passive_measures, through: :measure_actors
 
+  has_many :measure_measures, dependent: :destroy
+  has_many :measures, through: :measure_measures
+  has_many :other_measure_measures, class_name: "MeasureMeasure", dependent: :destroy, foreign_key: :other_measure_id
+
+  has_many :measure_resources, dependent: :destroy
+  has_many :resources, through: :measure_resources
+
   has_many :recommendations, through: :recommendation_measures, inverse_of: :measures
   has_many :categories, through: :measure_categories, inverse_of: :measures
   has_many :indicators, through: :measure_indicators, inverse_of: :measures
   has_many :due_dates, through: :indicators
   has_many :progress_reports, through: :indicators
+
+  has_many :user_measures, dependent: :destroy
+  has_many :users, through: :user_measures
 
   belongs_to :measuretype, required: true
   belongs_to :parent, class_name: "Measure", required: false

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -3,4 +3,7 @@ class Resource < VersionedRecord
 
   validates :title, presence: true
   validates :resourcetype_id, presence: true
+
+  has_many :measure_resources, dependent: :destroy
+  has_many :measures, through: :measure_resources
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,10 @@ class User < VersionedRecord
   has_many :user_categories, dependent: :destroy
   has_many :categories, through: :user_categories
   has_many :bookmarks, dependent: :destroy
+  has_many :user_actors, dependent: :destroy
+  has_many :actors, through: :user_actors
+  has_many :user_measures, dependent: :destroy
+  has_many :measures, through: :user_measures
 
   validates :email, presence: true
   validates :name, presence: true

--- a/spec/models/actor_spec.rb
+++ b/spec/models/actor_spec.rb
@@ -20,10 +20,11 @@ RSpec.describe Actor, type: :model do
     FactoryBot.create(:actor_measure, actor: actor)
     FactoryBot.create(:measure_actor, actor: actor)
     FactoryBot.create(:membership, member: actor, memberof: FactoryBot.create(:actor, actortype: FactoryBot.create(:actortype, has_members: true)))
+    FactoryBot.create(:user_actor, actor: actor)
 
     expect { actor.destroy }.to change {
-      [Actor.count, ActorCategory.count, ActorMeasure.count, MeasureActor.count, Membership.count]
-    }.from([2, 1, 1, 1, 1]).to([1, 0, 0, 0, 0])
+      [Actor.count, ActorCategory.count, ActorMeasure.count, MeasureActor.count, Membership.count, UserActor.count]
+    }.from([2, 1, 1, 1, 1, 1]).to([1, 0, 0, 0, 0, 0])
   end
 
   context "parent_id" do

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -63,18 +63,32 @@ RSpec.describe Measure, type: :model do
       FactoryBot.create(:measure_indicator, measure: measure)
       FactoryBot.create(:actor_measure, measure: measure)
       FactoryBot.create(:measure_actor, measure: measure)
+      FactoryBot.create(:measure_measure, measure: measure)
+      FactoryBot.create(:measure_resource, measure: measure)
       FactoryBot.create(:recommendation_measure, measure: measure)
+      FactoryBot.create(:user_measure, measure: measure)
 
       expect { measure.destroy }.to change {
         [
           Measure.count,
           MeasureCategory.count,
           MeasureIndicator.count,
+          MeasureMeasure.count,
+          MeasureResource.count,
           ActorMeasure.count,
           MeasureActor.count,
-          RecommendationMeasure.count
+          RecommendationMeasure.count,
+          UserMeasure.count
         ]
-      }.from([1, 1, 1, 1, 1, 1]).to([0, 0, 0, 0, 0, 0])
+      }.from([2, 1, 1, 1, 1, 1, 1, 1, 1]).to([1, 0, 0, 0, 0, 0, 0, 0, 0])
+    end
+
+    it "is expected to cascade destroy other_measure_measures relationships" do
+      measure_measure = FactoryBot.create(:measure_measure)
+
+      expect { measure_measure.other_measure.destroy }.to change {
+        Measure.count
+      }.from(2).to(1)
     end
   end
 end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -7,4 +7,15 @@ RSpec.describe Resource, type: :model do
   it "is expected to default private to false" do
     expect(subject.private).to eq(false)
   end
+
+  it "is expected to cascade destroy dependent relationships" do
+    resource = FactoryBot.create(:resource)
+
+    FactoryBot.create(:measure_resource, resource: resource)
+    expect { resource.destroy }.to change {
+      [
+        MeasureResource.count
+      ]
+    }.from([1]).to([0])
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -34,11 +34,13 @@ RSpec.describe User, type: :model do
 
   it "is expected to cascade destroy dependent relationships" do
     user = FactoryBot.create(:user_category).user
+    FactoryBot.create(:user_actor, user: user, created_by: user, updated_by: user)
+    FactoryBot.create(:user_measure, user: user, created_by: user, updated_by: user)
     FactoryBot.create(:user_role, user: user)
     FactoryBot.create(:bookmark, user: user)
 
     expect { user.destroy }.to change {
-      [User.count, UserCategory.count, UserRole.count, Bookmark.count]
-    }.from([1, 1, 1, 1]).to([0, 0, 0, 0])
+      [User.count, UserActor.count, UserCategory.count, UserMeasure.count, UserRole.count, Bookmark.count]
+    }.from([1, 1, 1, 1, 1, 1]).to([0, 0, 0, 0, 0, 0])
   end
 end


### PR DESCRIPTION
We need to make sure that ALL existing relationships also get deleted when deleting an entity, specifically measures, resources and actors

the affected join tables causing the issue are

- measure_resources
- measure_measures
- user_actors
- user_measures

Fixes #39 