### PR TITLE
Set `relationship_updated_at` when relationship changes

### DIFF
--- a/app/models/actor_category.rb
+++ b/app/models/actor_category.rb
@@ -20,6 +20,6 @@ class ActorCategory < VersionedRecord
   end
 
   def set_relationship_updated_at
-    actor.update_column(:relationship_updated_at, Time.zone.now)
+    actor.update_column(:relationship_updated_at, Time.zone.now) if actor && !actor.destroyed?
   end
 end

--- a/app/models/actor_category.rb
+++ b/app/models/actor_category.rb
@@ -9,11 +9,17 @@ class ActorCategory < VersionedRecord
   validates :category_id, presence: true, uniqueness: {scope: :actor_id}
   validate :category_taxonomy_enabled_for_actortype
 
+  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+
   private
 
   def category_taxonomy_enabled_for_actortype
     unless category&.taxonomy&.actortype_ids&.include?(actor&.actortype_id)
       errors.add(:category, "must have its taxonomy enabled for actor's actortype")
     end
+  end
+
+  def set_relationship_updated_at
+    actor.update_column(:relationship_updated_at, Time.zone.now)
   end
 end

--- a/app/models/actor_measure.rb
+++ b/app/models/actor_measure.rb
@@ -12,7 +12,7 @@ class ActorMeasure < VersionedRecord
   end
 
   def set_relationship_updated_at
-    actor.update_column(:relationship_updated_at, Time.zone.now)
-    measure.update_column(:relationship_updated_at, Time.zone.now)
+    actor.update_column(:relationship_updated_at, Time.zone.now) if actor && !actor.destroyed?
+    measure.update_column(:relationship_updated_at, Time.zone.now) if measure && !measure.destroyed?
   end
 end

--- a/app/models/actor_measure.rb
+++ b/app/models/actor_measure.rb
@@ -3,10 +3,16 @@ class ActorMeasure < VersionedRecord
   belongs_to :measure, required: true
 
   validate :actor_actortype_is_active
+  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
 
   private
 
   def actor_actortype_is_active
     errors.add(:actor, "actor's actortype is not active") unless actor&.actortype&.is_active
+  end
+
+  def set_relationship_updated_at
+    actor.update_column(:relationship_updated_at, Time.zone.now)
+    measure.update_column(:relationship_updated_at, Time.zone.now)
   end
 end

--- a/app/models/measure_actor.rb
+++ b/app/models/measure_actor.rb
@@ -17,7 +17,7 @@ class MeasureActor < VersionedRecord
   end
 
   def set_relationship_updated_at
-    actor.update_column(:relationship_updated_at, Time.zone.now)
-    measure.update_column(:relationship_updated_at, Time.zone.now)
+    actor.update_column(:relationship_updated_at, Time.zone.now) if actor && !actor.destroyed?
+    measure.update_column(:relationship_updated_at, Time.zone.now) if measure && !measure.destroyed?
   end
 end

--- a/app/models/measure_actor.rb
+++ b/app/models/measure_actor.rb
@@ -4,6 +4,8 @@ class MeasureActor < VersionedRecord
 
   validate :actor_actortype_is_target, :measure_measuretype_has_target
 
+  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+
   private
 
   def actor_actortype_is_target
@@ -12,5 +14,10 @@ class MeasureActor < VersionedRecord
 
   def measure_measuretype_has_target
     errors.add(:measure, "measure's measuretype can't have target") unless measure&.measuretype&.has_target
+  end
+
+  def set_relationship_updated_at
+    actor.update_column(:relationship_updated_at, Time.zone.now)
+    measure.update_column(:relationship_updated_at, Time.zone.now)
   end
 end

--- a/app/models/measure_category.rb
+++ b/app/models/measure_category.rb
@@ -21,6 +21,6 @@ class MeasureCategory < VersionedRecord
   end
 
   def set_relationship_updated_at
-    measure.update_column(:relationship_updated_at, Time.zone.now)
+    measure.update_column(:relationship_updated_at, Time.zone.now) if measure && !measure.destroyed?
   end
 end

--- a/app/models/measure_category.rb
+++ b/app/models/measure_category.rb
@@ -10,11 +10,17 @@ class MeasureCategory < VersionedRecord
 
   validate :category_taxonomy_enabled_for_measuretype
 
+  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+
   private
 
   def category_taxonomy_enabled_for_measuretype
     unless category&.taxonomy&.measuretype_ids&.include?(measure&.measuretype_id)
       errors.add(:measure_id, "must have the category's taxonomy enabled for its measuretype")
     end
+  end
+
+  def set_relationship_updated_at
+    measure.update_column(:relationship_updated_at, Time.zone.now)
   end
 end

--- a/app/models/measure_indicator.rb
+++ b/app/models/measure_indicator.rb
@@ -13,7 +13,7 @@ class MeasureIndicator < ApplicationRecord
   private
 
   def set_relationship_updated_at
-    measure.update_column(:relationship_updated_at, Time.zone.now)
-    indicator.update_column(:relationship_updated_at, Time.zone.now)
+    measure.update_column(:relationship_updated_at, Time.zone.now) if measure && !measure.destroyed?
+    indicator.update_column(:relationship_updated_at, Time.zone.now) if indicator && !indicator.destroyed?
   end
 end

--- a/app/models/measure_indicator.rb
+++ b/app/models/measure_indicator.rb
@@ -7,4 +7,13 @@ class MeasureIndicator < ApplicationRecord
   validates :measure_id, uniqueness: {scope: :indicator_id}
   validates :measure_id, presence: true
   validates :indicator_id, presence: true
+
+  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+
+  private
+
+  def set_relationship_updated_at
+    measure.update_column(:relationship_updated_at, Time.zone.now)
+    indicator.update_column(:relationship_updated_at, Time.zone.now)
+  end
 end

--- a/app/models/measure_measure.rb
+++ b/app/models/measure_measure.rb
@@ -17,7 +17,7 @@ class MeasureMeasure < VersionedRecord
   end
 
   def set_relationship_updated_at
-    measure.update_column(:relationship_updated_at, Time.zone.now)
-    other_measure.update_column(:relationship_updated_at, Time.zone.now)
+    measure.update_column(:relationship_updated_at, Time.zone.now) if measure && !measure.destroyed?
+    other_measure.update_column(:relationship_updated_at, Time.zone.now) if other_measure && !other_measure.destroyed?
   end
 end

--- a/app/models/measure_measure.rb
+++ b/app/models/measure_measure.rb
@@ -8,9 +8,16 @@ class MeasureMeasure < VersionedRecord
 
   validate :measure_not_other_measure
 
+  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+
   private
 
   def measure_not_other_measure
     errors.add(:measure, "can't be the same as other_measure") if measure == other_measure
+  end
+
+  def set_relationship_updated_at
+    measure.update_column(:relationship_updated_at, Time.zone.now)
+    other_measure.update_column(:relationship_updated_at, Time.zone.now)
   end
 end

--- a/app/models/measure_resource.rb
+++ b/app/models/measure_resource.rb
@@ -13,6 +13,6 @@ class MeasureResource < VersionedRecord
   private
 
   def set_relationship_updated_at
-    measure.update_column(:relationship_updated_at, Time.zone.now)
+    measure.update_column(:relationship_updated_at, Time.zone.now) if measure && !measure.destroyed?
   end
 end

--- a/app/models/measure_resource.rb
+++ b/app/models/measure_resource.rb
@@ -7,4 +7,12 @@ class MeasureResource < VersionedRecord
 
   validates :measure_id, presence: true
   validates :resource_id, presence: true, uniqueness: {scope: :measure_id}
+
+  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+
+  private
+
+  def set_relationship_updated_at
+    measure.update_column(:relationship_updated_at, Time.zone.now)
+  end
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -6,9 +6,16 @@ class Membership < VersionedRecord
 
   validate :member_not_memberof
 
+  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+
   private
 
   def member_not_memberof
     errors.add(:member, "can't be the same as memberof") if member == memberof
+  end
+
+  def set_relationship_updated_at
+    member.update_column(:relationship_updated_at, Time.zone.now)
+    memberof.update_column(:relationship_updated_at, Time.zone.now)
   end
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -15,7 +15,7 @@ class Membership < VersionedRecord
   end
 
   def set_relationship_updated_at
-    member.update_column(:relationship_updated_at, Time.zone.now)
-    memberof.update_column(:relationship_updated_at, Time.zone.now)
+    member.update_column(:relationship_updated_at, Time.zone.now) if member && !member.destroyed?
+    memberof.update_column(:relationship_updated_at, Time.zone.now) if memberof && !memberof.destroyed?
   end
 end

--- a/app/models/user_actor.rb
+++ b/app/models/user_actor.rb
@@ -5,4 +5,13 @@ class UserActor < VersionedRecord
   validates :user_id, uniqueness: {scope: :actor_id}
   validates :user_id, presence: true
   validates :actor_id, presence: true
+
+  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+
+  private
+
+  def set_relationship_updated_at
+    actor.update_column(:relationship_updated_at, Time.zone.now)
+    user.update_column(:relationship_updated_at, Time.zone.now)
+  end
 end

--- a/app/models/user_actor.rb
+++ b/app/models/user_actor.rb
@@ -11,7 +11,7 @@ class UserActor < VersionedRecord
   private
 
   def set_relationship_updated_at
-    actor.update_column(:relationship_updated_at, Time.zone.now)
-    user.update_column(:relationship_updated_at, Time.zone.now)
+    actor.update_column(:relationship_updated_at, Time.zone.now) if actor && !actor.destroyed?
+    user.update_column(:relationship_updated_at, Time.zone.now) if user && !user.destroyed?
   end
 end

--- a/app/models/user_category.rb
+++ b/app/models/user_category.rb
@@ -5,4 +5,12 @@ class UserCategory < ApplicationRecord
   validates :user_id, uniqueness: {scope: :category_id}
   validates :user_id, presence: true
   validates :category_id, presence: true
+
+  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+
+  private
+
+  def set_relationship_updated_at
+    user&.update_column(:relationship_updated_at, Time.zone.now)
+  end
 end

--- a/app/models/user_category.rb
+++ b/app/models/user_category.rb
@@ -11,6 +11,6 @@ class UserCategory < ApplicationRecord
   private
 
   def set_relationship_updated_at
-    user&.update_column(:relationship_updated_at, Time.zone.now)
+    user.update_column(:relationship_updated_at, Time.zone.now) if user && !user.destroyed?
   end
 end

--- a/app/models/user_measure.rb
+++ b/app/models/user_measure.rb
@@ -11,7 +11,7 @@ class UserMeasure < VersionedRecord
   private
 
   def set_relationship_updated_at
-    measure.update_column(:relationship_updated_at, Time.zone.now)
-    user.update_column(:relationship_updated_at, Time.zone.now)
+    measure.update_column(:relationship_updated_at, Time.zone.now) if measure && !measure.destroyed?
+    user.update_column(:relationship_updated_at, Time.zone.now) if user && !user.destroyed?
   end
 end

--- a/app/models/user_measure.rb
+++ b/app/models/user_measure.rb
@@ -5,4 +5,13 @@ class UserMeasure < VersionedRecord
   validates :user_id, uniqueness: {scope: :measure_id}
   validates :user_id, presence: true
   validates :measure_id, presence: true
+
+  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+
+  private
+
+  def set_relationship_updated_at
+    measure.update_column(:relationship_updated_at, Time.zone.now)
+    user.update_column(:relationship_updated_at, Time.zone.now)
+  end
 end

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -5,4 +5,12 @@ class UserRole < VersionedRecord
   validates :user_id, uniqueness: {scope: :role_id}
 
   delegate :name, to: :role, prefix: true, allow_nil: true
+
+  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+
+  private
+
+  def set_relationship_updated_at
+    user.update_column(:relationship_updated_at, Time.zone.now) if user && !user.destroyed?
+  end
 end

--- a/db/migrate/20220830085433_add_relationship_updated_at_to_tables_with_joins.rb
+++ b/db/migrate/20220830085433_add_relationship_updated_at_to_tables_with_joins.rb
@@ -1,0 +1,8 @@
+class AddRelationshipUpdatedAtToTablesWithJoins < ActiveRecord::Migration[6.1]
+  def change
+    add_column :actors, :relationship_updated_at, :datetime, precision: 6, null: true
+    add_column :indicators, :relationship_updated_at, :datetime, precision: 6, null: true
+    add_column :measures, :relationship_updated_at, :datetime, precision: 6, null: true
+    add_column :users, :relationship_updated_at, :datetime, precision: 6, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_11_081635) do
+ActiveRecord::Schema.define(version: 2022_08_30_085433) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 2022_08_11_081635) do
     t.bigint "manager_id"
     t.bigint "parent_id"
     t.boolean "is_archive", default: false
+    t.datetime "relationship_updated_at", precision: 6
     t.index ["actortype_id"], name: "index_actors_on_actortype_id"
     t.index ["created_by_id"], name: "index_actors_on_created_by_id"
     t.index ["manager_id"], name: "index_actors_on_manager_id"
@@ -187,6 +188,7 @@ ActiveRecord::Schema.define(version: 2022_08_11_081635) do
     t.boolean "private", default: false
     t.boolean "is_archive", default: false
     t.string "code"
+    t.datetime "relationship_updated_at", precision: 6
     t.index ["created_at"], name: "index_indicators_on_created_at"
     t.index ["draft"], name: "index_indicators_on_draft"
     t.index ["manager_id"], name: "index_indicators_on_manager_id"
@@ -288,6 +290,7 @@ ActiveRecord::Schema.define(version: 2022_08_11_081635) do
     t.boolean "private", default: false
     t.boolean "is_archive", default: false
     t.boolean "notifications", default: true
+    t.datetime "relationship_updated_at", precision: 6
     t.index ["draft"], name: "index_measures_on_draft"
     t.index ["measuretype_id"], name: "index_measures_on_measuretype_id"
     t.index ["parent_id"], name: "index_measures_on_parent_id"
@@ -528,6 +531,7 @@ ActiveRecord::Schema.define(version: 2022_08_11_081635) do
     t.integer "updated_by_id"
     t.boolean "allow_password_change", default: true
     t.integer "created_by_id"
+    t.datetime "relationship_updated_at", precision: 6
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/models/actor_category_spec.rb
+++ b/spec/models/actor_category_spec.rb
@@ -25,19 +25,19 @@ RSpec.describe ActorCategory, type: :model do
   context "with an actor and a category" do
     let!(:taxonomy) { FactoryBot.create(:actortype_taxonomy, actortype: actor.actortype, taxonomy: category.taxonomy) }
 
+    subject { described_class.create(actor: actor, category: category) }
+
     it "create sets the relationship_updated_at on the actor" do
-      expect { described_class.create(actor: actor, category: category) }
-        .to change { actor.reload.relationship_updated_at }
+      expect { subject }.to change { actor.reload.relationship_updated_at }
     end
 
     it "update sets the relationship_updated_at on the actor" do
-      relationship = described_class.create(actor: actor, category: category)
-      expect { relationship.touch }.to change { actor.reload.relationship_updated_at }
+      subject
+      expect { subject.touch }.to change { actor.reload.relationship_updated_at }
     end
 
     it "destroy sets the relationship_updated_at on the actor" do
-      relationship = described_class.create(actor: actor, category: category)
-      expect { relationship.destroy }.to change { actor.reload.relationship_updated_at }
+      expect { subject.destroy }.to change { actor.reload.relationship_updated_at }
     end
   end
 end

--- a/spec/models/actor_category_spec.rb
+++ b/spec/models/actor_category_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe ActorCategory, type: :model do
   end
 
   context "with an actor and a category" do
-    let(:actor) { FactoryBot.create(:actor) }
     let!(:taxonomy) { FactoryBot.create(:actortype_taxonomy, actortype: actor.actortype, taxonomy: category.taxonomy) }
 
     it "create sets the relationship_updated_at on the actor" do

--- a/spec/models/actor_category_spec.rb
+++ b/spec/models/actor_category_spec.rb
@@ -21,4 +21,24 @@ RSpec.describe ActorCategory, type: :model do
     actor_category = described_class.create(category: category, actor: actor)
     expect(actor_category).to be_valid
   end
+
+  context "with an actor and a category" do
+    let(:actor) { FactoryBot.create(:actor) }
+    let!(:taxonomy) { FactoryBot.create(:actortype_taxonomy, actortype: actor.actortype, taxonomy: category.taxonomy) }
+
+    it "create sets the relationship_updated_at on the actor" do
+      expect { described_class.create(actor: actor, category: category) }
+        .to change { actor.reload.relationship_updated_at }
+    end
+
+    it "update sets the relationship_updated_at on the actor" do
+      relationship = described_class.create(actor: actor, category: category)
+      expect { relationship.touch }.to change { actor.reload.relationship_updated_at }
+    end
+
+    it "destroy sets the relationship_updated_at on the actor" do
+      relationship = described_class.create(actor: actor, category: category)
+      expect { relationship.destroy }.to change { actor.reload.relationship_updated_at }
+    end
+  end
 end

--- a/spec/models/actor_measure_spec.rb
+++ b/spec/models/actor_measure_spec.rb
@@ -21,4 +21,39 @@ RSpec.describe ActorMeasure, type: :model do
     expect(actor_measure).to be_invalid
     expect(actor_measure.errors[:actor]).to(include("actor's actortype is not active"))
   end
+
+  context "with an actor and a measure" do
+    let(:actor) { FactoryBot.create(:actor) }
+    let(:measure) { FactoryBot.create(:measure) }
+
+    it "create sets the relationship_updated_at on the actor" do
+      expect { described_class.create(actor: actor, measure: measure) }
+        .to change { actor.reload.relationship_updated_at }
+    end
+
+    it "create sets the relationship_updated_at on the measure" do
+      expect { described_class.create(actor: actor, measure: measure) }
+        .to change { measure.reload.relationship_updated_at }
+    end
+
+    it "update sets the relationship_updated_at on the actor" do
+      relationship = described_class.create(actor: actor, measure: measure)
+      expect { relationship.touch }.to change { actor.reload.relationship_updated_at }
+    end
+
+    it "update sets the relationship_updated_at on the measure" do
+      relationship = described_class.create(actor: actor, measure: measure)
+      expect { relationship.touch }.to change { measure.reload.relationship_updated_at }
+    end
+
+    it "destroy sets the relationship_updated_at on the actor" do
+      relationship = described_class.create(actor: actor, measure: measure)
+      expect { relationship.destroy }.to change { actor.reload.relationship_updated_at }
+    end
+
+    it "destroy sets the relationship_updated_at on the measure" do
+      relationship = described_class.create(actor: actor, measure: measure)
+      expect { relationship.destroy }.to change { measure.reload.relationship_updated_at }
+    end
+  end
 end

--- a/spec/models/actor_measure_spec.rb
+++ b/spec/models/actor_measure_spec.rb
@@ -26,34 +26,32 @@ RSpec.describe ActorMeasure, type: :model do
     let(:actor) { FactoryBot.create(:actor) }
     let(:measure) { FactoryBot.create(:measure) }
 
+    subject { described_class.create(actor: actor, measure: measure) }
+
     it "create sets the relationship_updated_at on the actor" do
-      expect { described_class.create(actor: actor, measure: measure) }
-        .to change { actor.reload.relationship_updated_at }
+      expect { subject }.to change { actor.reload.relationship_updated_at }
     end
 
     it "create sets the relationship_updated_at on the measure" do
-      expect { described_class.create(actor: actor, measure: measure) }
-        .to change { measure.reload.relationship_updated_at }
+      expect { subject }.to change { measure.reload.relationship_updated_at }
     end
 
     it "update sets the relationship_updated_at on the actor" do
-      relationship = described_class.create(actor: actor, measure: measure)
-      expect { relationship.touch }.to change { actor.reload.relationship_updated_at }
+      subject
+      expect { subject.touch }.to change { actor.reload.relationship_updated_at }
     end
 
     it "update sets the relationship_updated_at on the measure" do
-      relationship = described_class.create(actor: actor, measure: measure)
-      expect { relationship.touch }.to change { measure.reload.relationship_updated_at }
+      subject
+      expect { subject.touch }.to change { measure.reload.relationship_updated_at }
     end
 
     it "destroy sets the relationship_updated_at on the actor" do
-      relationship = described_class.create(actor: actor, measure: measure)
-      expect { relationship.destroy }.to change { actor.reload.relationship_updated_at }
+      expect { subject.destroy }.to change { actor.reload.relationship_updated_at }
     end
 
     it "destroy sets the relationship_updated_at on the measure" do
-      relationship = described_class.create(actor: actor, measure: measure)
-      expect { relationship.destroy }.to change { measure.reload.relationship_updated_at }
+      expect { subject.destroy }.to change { measure.reload.relationship_updated_at }
     end
   end
 end

--- a/spec/models/measure_actors_spec.rb
+++ b/spec/models/measure_actors_spec.rb
@@ -39,4 +39,39 @@ RSpec.describe MeasureActor, type: :model do
     expect(measure_actor).to be_invalid
     expect(measure_actor.errors[:measure]).to(include("measure's measuretype can't have target"))
   end
+
+  context "with an actor and a measure" do
+    let(:actor) { FactoryBot.create(:actor) }
+    let(:measure) { FactoryBot.create(:measure) }
+
+    it "create sets the relationship_updated_at on the actor" do
+      expect { described_class.create(actor: actor, measure: measure) }
+        .to change { actor.reload.relationship_updated_at }
+    end
+
+    it "create sets the relationship_updated_at on the measure" do
+      expect { described_class.create(actor: actor, measure: measure) }
+        .to change { measure.reload.relationship_updated_at }
+    end
+
+    it "update sets the relationship_updated_at on the actor" do
+      relationship = described_class.create(actor: actor, measure: measure)
+      expect { relationship.touch }.to change { actor.reload.relationship_updated_at }
+    end
+
+    it "update sets the relationship_updated_at on the measure" do
+      relationship = described_class.create(actor: actor, measure: measure)
+      expect { relationship.touch }.to change { measure.reload.relationship_updated_at }
+    end
+
+    it "destroy sets the relationship_updated_at on the actor" do
+      relationship = described_class.create(actor: actor, measure: measure)
+      expect { relationship.destroy }.to change { actor.reload.relationship_updated_at }
+    end
+
+    it "destroy sets the relationship_updated_at on the measure" do
+      relationship = described_class.create(actor: actor, measure: measure)
+      expect { relationship.destroy }.to change { measure.reload.relationship_updated_at }
+    end
+  end
 end

--- a/spec/models/measure_actors_spec.rb
+++ b/spec/models/measure_actors_spec.rb
@@ -44,34 +44,32 @@ RSpec.describe MeasureActor, type: :model do
     let(:actor) { FactoryBot.create(:actor) }
     let(:measure) { FactoryBot.create(:measure) }
 
+    subject { described_class.create(actor: actor, measure: measure) }
+
     it "create sets the relationship_updated_at on the actor" do
-      expect { described_class.create(actor: actor, measure: measure) }
-        .to change { actor.reload.relationship_updated_at }
+      expect { subject }.to change { actor.reload.relationship_updated_at }
     end
 
     it "create sets the relationship_updated_at on the measure" do
-      expect { described_class.create(actor: actor, measure: measure) }
-        .to change { measure.reload.relationship_updated_at }
+      expect { subject }.to change { measure.reload.relationship_updated_at }
     end
 
     it "update sets the relationship_updated_at on the actor" do
-      relationship = described_class.create(actor: actor, measure: measure)
-      expect { relationship.touch }.to change { actor.reload.relationship_updated_at }
+      subject
+      expect { subject.touch }.to change { actor.reload.relationship_updated_at }
     end
 
     it "update sets the relationship_updated_at on the measure" do
-      relationship = described_class.create(actor: actor, measure: measure)
-      expect { relationship.touch }.to change { measure.reload.relationship_updated_at }
+      subject
+      expect { subject.touch }.to change { measure.reload.relationship_updated_at }
     end
 
     it "destroy sets the relationship_updated_at on the actor" do
-      relationship = described_class.create(actor: actor, measure: measure)
-      expect { relationship.destroy }.to change { actor.reload.relationship_updated_at }
+      expect { subject.destroy }.to change { actor.reload.relationship_updated_at }
     end
 
     it "destroy sets the relationship_updated_at on the measure" do
-      relationship = described_class.create(actor: actor, measure: measure)
-      expect { relationship.destroy }.to change { measure.reload.relationship_updated_at }
+      expect { subject.destroy }.to change { measure.reload.relationship_updated_at }
     end
   end
 end

--- a/spec/models/measure_category_spec.rb
+++ b/spec/models/measure_category_spec.rb
@@ -16,10 +16,26 @@ RSpec.describe MeasureCategory, type: :model do
     expect(measure_category.errors[:measure_id]).to include("must have the category's taxonomy enabled for its measuretype")
   end
 
-  it "works when the category's taxonomy is enabled for its measuretype" do
-    FactoryBot.create(:measuretype_taxonomy, measuretype: measure.measuretype, taxonomy: category.taxonomy)
+  context "when the category's taxonomy is enabled for its measuretype" do
+    let!(:measuretype_taxonomy) { FactoryBot.create(:measuretype_taxonomy, measuretype: measure.measuretype, taxonomy: category.taxonomy) }
 
-    measure_category = described_class.create(category: category, measure: measure)
-    expect(measure_category).to be_valid
+    subject { described_class.create(category: category, measure: measure) }
+
+    it "works" do
+      expect(subject).to be_valid
+    end
+
+    it "create sets the relationship_updated_at on the measure" do
+      expect { subject }.to change { measure.reload.relationship_updated_at }
+    end
+
+    it "update sets the relationship_updated_at on the measure" do
+      subject
+      expect { subject.touch }.to change { measure.reload.relationship_updated_at }
+    end
+
+    it "destroy sets the relationship_updated_at on the measure" do
+      expect { subject.destroy }.to change { measure.reload.relationship_updated_at }
+    end
   end
 end

--- a/spec/models/measure_indicator_spec.rb
+++ b/spec/models/measure_indicator_spec.rb
@@ -6,4 +6,37 @@ RSpec.describe MeasureIndicator, type: :model do
   it { is_expected.to validate_uniqueness_of(:measure_id).scoped_to(:indicator_id) }
   it { is_expected.to validate_presence_of(:measure_id) }
   it { is_expected.to validate_presence_of(:indicator_id) }
+
+  context "with an indicator and a measure" do
+    let(:indicator) { FactoryBot.create(:indicator) }
+    let(:measure) { FactoryBot.create(:measure) }
+
+    subject { described_class.create(indicator: indicator, measure: measure) }
+
+    it "create sets the relationship_updated_at on the indicator" do
+      expect { subject }.to change { indicator.reload.relationship_updated_at }
+    end
+
+    it "create sets the relationship_updated_at on the measure" do
+      expect { subject }.to change { measure.reload.relationship_updated_at }
+    end
+
+    it "update sets the relationship_updated_at on the indicator" do
+      subject
+      expect { subject.touch }.to change { indicator.reload.relationship_updated_at }
+    end
+
+    it "update sets the relationship_updated_at on the measure" do
+      subject
+      expect { subject.touch }.to change { measure.reload.relationship_updated_at }
+    end
+
+    it "destroy sets the relationship_updated_at on the indicator" do
+      expect { subject.destroy }.to change { indicator.reload.relationship_updated_at }
+    end
+
+    it "destroy sets the relationship_updated_at on the measure" do
+      expect { subject.destroy }.to change { measure.reload.relationship_updated_at }
+    end
+  end
 end

--- a/spec/models/measure_measure_spec.rb
+++ b/spec/models/measure_measure_spec.rb
@@ -14,4 +14,37 @@ RSpec.describe MeasureMeasure, type: :model do
     expect(measure_measure).to be_invalid
     expect(measure_measure.errors[:measure]).to include("can't be the same as other_measure")
   end
+
+  context "with an other_measure and a measure" do
+    let(:other_measure) { FactoryBot.create(:measure) }
+    let(:measure) { FactoryBot.create(:measure) }
+
+    subject { described_class.create(other_measure: other_measure, measure: measure) }
+
+    it "create sets the relationship_updated_at on the other_measure" do
+      expect { subject }.to change { other_measure.reload.relationship_updated_at }
+    end
+
+    it "create sets the relationship_updated_at on the measure" do
+      expect { subject }.to change { measure.reload.relationship_updated_at }
+    end
+
+    it "update sets the relationship_updated_at on the other_measure" do
+      subject
+      expect { subject.touch }.to change { other_measure.reload.relationship_updated_at }
+    end
+
+    it "update sets the relationship_updated_at on the measure" do
+      subject
+      expect { subject.touch }.to change { measure.reload.relationship_updated_at }
+    end
+
+    it "destroy sets the relationship_updated_at on the other_measure" do
+      expect { subject.destroy }.to change { other_measure.reload.relationship_updated_at }
+    end
+
+    it "destroy sets the relationship_updated_at on the measure" do
+      expect { subject.destroy }.to change { measure.reload.relationship_updated_at }
+    end
+  end
 end

--- a/spec/models/measure_resource_spec.rb
+++ b/spec/models/measure_resource_spec.rb
@@ -1,8 +1,28 @@
 require "rails_helper"
 
 RSpec.describe MeasureResource, type: :model do
-  it { is_expected.to belong_to :measure }
+  it { is_expected.to belong_to :resource }
   it { is_expected.to belong_to :resource }
   it { is_expected.to validate_presence_of :resource_id }
   it { is_expected.to validate_presence_of :measure_id }
+
+  context "with a measure and a resource" do
+    let(:measure) { FactoryBot.create(:measure) }
+    let(:resource) { FactoryBot.create(:resource) }
+
+    subject { described_class.create(measure: measure, resource: resource) }
+
+    it "create sets the relationship_updated_at on the measure" do
+      expect { subject }.to change { measure.reload.relationship_updated_at }
+    end
+
+    it "update sets the relationship_updated_at on the measure" do
+      subject
+      expect { subject.touch }.to change { measure.reload.relationship_updated_at }
+    end
+
+    it "destroy sets the relationship_updated_at on the measure" do
+      expect { subject.destroy }.to change { measure.reload.relationship_updated_at }
+    end
+  end
 end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -19,34 +19,32 @@ RSpec.describe Membership, type: :model do
   end
 
   context "with a member and a memberof" do
+    subject { described_class.create(member: member, memberof: memberof) }
+
     it "create sets the relationship_updated_at on the member" do
-      expect { described_class.create(member: member, memberof: memberof) }
-        .to change { member.reload.relationship_updated_at }
+      expect { subject }.to change { member.reload.relationship_updated_at }
     end
 
     it "create sets the relationship_updated_at on the memberof" do
-      expect { described_class.create(member: member, memberof: memberof) }
-        .to change { memberof.reload.relationship_updated_at }
+      expect { subject }.to change { memberof.reload.relationship_updated_at }
     end
 
     it "update sets the relationship_updated_at on the member" do
-      relationship = described_class.create(member: member, memberof: memberof)
-      expect { relationship.touch }.to change { member.reload.relationship_updated_at }
+      subject
+      expect { subject.touch }.to change { member.reload.relationship_updated_at }
     end
 
     it "update sets the relationship_updated_at on the memberof" do
-      relationship = described_class.create(member: member, memberof: memberof)
-      expect { relationship.touch }.to change { memberof.reload.relationship_updated_at }
+      subject
+      expect { subject.touch }.to change { memberof.reload.relationship_updated_at }
     end
 
     it "destroy sets the relationship_updated_at on the member" do
-      relationship = described_class.create(member: member, memberof: memberof)
-      expect { relationship.destroy }.to change { member.reload.relationship_updated_at }
+      expect { subject.destroy }.to change { member.reload.relationship_updated_at }
     end
 
     it "destroy sets the relationship_updated_at on the memberof" do
-      relationship = described_class.create(member: member, memberof: memberof)
-      expect { relationship.destroy }.to change { memberof.reload.relationship_updated_at }
+      expect { subject.destroy }.to change { memberof.reload.relationship_updated_at }
     end
   end
 end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -4,17 +4,49 @@ RSpec.describe Membership, type: :model do
   it { is_expected.to belong_to :member }
   it { is_expected.to belong_to :memberof }
 
+  let(:member) { FactoryBot.create(:actor) }
+  let(:memberof) { FactoryBot.create(:actor, actortype: FactoryBot.create(:actortype, :with_members)) }
+
   it "errors when the member is the same as the memberof" do
-    member = FactoryBot.create(:actor)
     membership = described_class.create(member: member, memberof: member)
     expect(membership).to be_invalid
     expect(membership.errors[:member]).to include("can't be the same as memberof")
   end
 
   it "works when the memberof can have members" do
-    member = FactoryBot.create(:actor)
-    memberof = FactoryBot.create(:actor, actortype: FactoryBot.create(:actortype, :with_members))
     membership = described_class.create(member: member, memberof: memberof)
     expect(membership).to be_valid
+  end
+
+  context "with a member and a memberof" do
+    it "create sets the relationship_updated_at on the member" do
+      expect { described_class.create(member: member, memberof: memberof) }
+        .to change { member.reload.relationship_updated_at }
+    end
+
+    it "create sets the relationship_updated_at on the memberof" do
+      expect { described_class.create(member: member, memberof: memberof) }
+        .to change { memberof.reload.relationship_updated_at }
+    end
+
+    it "update sets the relationship_updated_at on the member" do
+      relationship = described_class.create(member: member, memberof: memberof)
+      expect { relationship.touch }.to change { member.reload.relationship_updated_at }
+    end
+
+    it "update sets the relationship_updated_at on the memberof" do
+      relationship = described_class.create(member: member, memberof: memberof)
+      expect { relationship.touch }.to change { memberof.reload.relationship_updated_at }
+    end
+
+    it "destroy sets the relationship_updated_at on the member" do
+      relationship = described_class.create(member: member, memberof: memberof)
+      expect { relationship.destroy }.to change { member.reload.relationship_updated_at }
+    end
+
+    it "destroy sets the relationship_updated_at on the memberof" do
+      relationship = described_class.create(member: member, memberof: memberof)
+      expect { relationship.destroy }.to change { memberof.reload.relationship_updated_at }
+    end
   end
 end

--- a/spec/models/user_actor_spec.rb
+++ b/spec/models/user_actor_spec.rb
@@ -7,4 +7,39 @@ RSpec.describe UserActor, type: :model do
   # it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(:actor_id) }
   it { is_expected.to validate_presence_of(:user_id) }
   it { is_expected.to validate_presence_of(:actor_id) }
+
+  context "with an actor and a user" do
+    let(:actor) { FactoryBot.create(:actor) }
+    let(:user) { FactoryBot.create(:user) }
+
+    it "create sets the relationship_updated_at on the actor" do
+      expect { described_class.create(actor: actor, user: user) }
+        .to change { actor.reload.relationship_updated_at }
+    end
+
+    it "create sets the relationship_updated_at on the user" do
+      expect { described_class.create(actor: actor, user: user) }
+        .to change { user.reload.relationship_updated_at }
+    end
+
+    it "update sets the relationship_updated_at on the actor" do
+      relationship = described_class.create(actor: actor, user: user)
+      expect { relationship.touch }.to change { actor.reload.relationship_updated_at }
+    end
+
+    it "update sets the relationship_updated_at on the user" do
+      relationship = described_class.create(actor: actor, user: user)
+      expect { relationship.touch }.to change { user.reload.relationship_updated_at }
+    end
+
+    it "destroy sets the relationship_updated_at on the actor" do
+      relationship = described_class.create(actor: actor, user: user)
+      expect { relationship.destroy }.to change { actor.reload.relationship_updated_at }
+    end
+
+    it "destroy sets the relationship_updated_at on the user" do
+      relationship = described_class.create(actor: actor, user: user)
+      expect { relationship.destroy }.to change { user.reload.relationship_updated_at }
+    end
+  end
 end

--- a/spec/models/user_actor_spec.rb
+++ b/spec/models/user_actor_spec.rb
@@ -12,34 +12,32 @@ RSpec.describe UserActor, type: :model do
     let(:actor) { FactoryBot.create(:actor) }
     let(:user) { FactoryBot.create(:user) }
 
+    subject { described_class.create(actor: actor, user: user) }
+
     it "create sets the relationship_updated_at on the actor" do
-      expect { described_class.create(actor: actor, user: user) }
-        .to change { actor.reload.relationship_updated_at }
+      expect { subject }.to change { actor.reload.relationship_updated_at }
     end
 
     it "create sets the relationship_updated_at on the user" do
-      expect { described_class.create(actor: actor, user: user) }
-        .to change { user.reload.relationship_updated_at }
+      expect { subject }.to change { user.reload.relationship_updated_at }
     end
 
     it "update sets the relationship_updated_at on the actor" do
-      relationship = described_class.create(actor: actor, user: user)
-      expect { relationship.touch }.to change { actor.reload.relationship_updated_at }
+      subject
+      expect { subject.touch }.to change { actor.reload.relationship_updated_at }
     end
 
     it "update sets the relationship_updated_at on the user" do
-      relationship = described_class.create(actor: actor, user: user)
-      expect { relationship.touch }.to change { user.reload.relationship_updated_at }
+      subject
+      expect { subject.touch }.to change { user.reload.relationship_updated_at }
     end
 
     it "destroy sets the relationship_updated_at on the actor" do
-      relationship = described_class.create(actor: actor, user: user)
-      expect { relationship.destroy }.to change { actor.reload.relationship_updated_at }
+      expect { subject.destroy }.to change { actor.reload.relationship_updated_at }
     end
 
     it "destroy sets the relationship_updated_at on the user" do
-      relationship = described_class.create(actor: actor, user: user)
-      expect { relationship.destroy }.to change { user.reload.relationship_updated_at }
+      expect { subject.destroy }.to change { user.reload.relationship_updated_at }
     end
   end
 end

--- a/spec/models/user_category_spec.rb
+++ b/spec/models/user_category_spec.rb
@@ -6,4 +6,13 @@ RSpec.describe UserCategory, type: :model do
   it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(:category_id) }
   it { is_expected.to validate_presence_of(:user_id) }
   it { is_expected.to validate_presence_of(:category_id) }
+
+  context "with a user" do
+    let(:user) { FactoryBot.create(:user) }
+
+    it "should set the relationship_updated_at on the user" do
+      expect { FactoryBot.create(:user_category, user: user) }
+        .to change { user.reload.relationship_updated_at }
+    end
+  end
 end

--- a/spec/models/user_category_spec.rb
+++ b/spec/models/user_category_spec.rb
@@ -7,12 +7,23 @@ RSpec.describe UserCategory, type: :model do
   it { is_expected.to validate_presence_of(:user_id) }
   it { is_expected.to validate_presence_of(:category_id) }
 
-  context "with a user" do
+  context "with a user and a category" do
     let(:user) { FactoryBot.create(:user) }
+    let(:category) { FactoryBot.create(:category) }
 
-    it "should set the relationship_updated_at on the user" do
-      expect { FactoryBot.create(:user_category, user: user) }
-        .to change { user.reload.relationship_updated_at }
+    subject { described_class.create(user: user, category: category) }
+
+    it "create sets the relationship_updated_at on the user" do
+      expect { subject }.to change { user.reload.relationship_updated_at }
+    end
+
+    it "update sets the relationship_updated_at on the user" do
+      subject
+      expect { subject.touch }.to change { user.reload.relationship_updated_at }
+    end
+
+    it "destroy sets the relationship_updated_at on the user" do
+      expect { subject.destroy }.to change { user.reload.relationship_updated_at }
     end
   end
 end

--- a/spec/models/user_measure_spec.rb
+++ b/spec/models/user_measure_spec.rb
@@ -7,4 +7,37 @@ RSpec.describe UserMeasure, type: :model do
   # it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(:measure_id) }
   it { is_expected.to validate_presence_of(:user_id) }
   it { is_expected.to validate_presence_of(:measure_id) }
+
+  context "with a user and a measure" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:measure) { FactoryBot.create(:measure) }
+
+    subject { described_class.create(user: user, measure: measure) }
+
+    it "create sets the relationship_updated_at on the user" do
+      expect { subject }.to change { user.reload.relationship_updated_at }
+    end
+
+    it "create sets the relationship_updated_at on the measure" do
+      expect { subject }.to change { measure.reload.relationship_updated_at }
+    end
+
+    it "update sets the relationship_updated_at on the user" do
+      subject
+      expect { subject.touch }.to change { user.reload.relationship_updated_at }
+    end
+
+    it "update sets the relationship_updated_at on the measure" do
+      subject
+      expect { subject.touch }.to change { measure.reload.relationship_updated_at }
+    end
+
+    it "destroy sets the relationship_updated_at on the user" do
+      expect { subject.destroy }.to change { user.reload.relationship_updated_at }
+    end
+
+    it "destroy sets the relationship_updated_at on the measure" do
+      expect { subject.destroy }.to change { measure.reload.relationship_updated_at }
+    end
+  end
 end

--- a/spec/models/user_role_spec.rb
+++ b/spec/models/user_role_spec.rb
@@ -4,4 +4,24 @@ RSpec.describe UserRole, type: :model do
   it { is_expected.to belong_to :user }
   it { is_expected.to belong_to :role }
   # it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(:role_id) }
+
+  context "with a user and a role" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:role) { FactoryBot.create(:role) }
+
+    subject { described_class.create(user: user, role: role) }
+
+    it "create sets the relationship_updated_at on the user" do
+      expect { subject }.to change { user.reload.relationship_updated_at }
+    end
+
+    it "update sets the relationship_updated_at on the user" do
+      subject
+      expect { subject.touch }.to change { user.reload.relationship_updated_at }
+    end
+
+    it "destroy sets the relationship_updated_at on the user" do
+      expect { subject.destroy }.to change { user.reload.relationship_updated_at }
+    end
+  end
 end


### PR DESCRIPTION
Track updates to relationships in all related tables by adding a new field `relationship_updated_at` to all principal tables (see below) that is updated with the current date anytime a change happens to a relationship (create/update/delete)

Specifically the principal tables are (with join tables nested)

- [x] actors
  - [x] actor_categories 
  - [x] actor_measures
  - [x] measure_actors
  - [x] memberships
  - [x] user_actors
- [x] measures
  - [x] actor_measures
  - [x] measure_actors
  - [x] measure_categories
  - [x] measure_indicators
  - [x] measure_measures
  - [x] measure_resources
  - [x] user_measures
- [x] indicators
  - [x] measure_indicators
- [x] users
  - [x] user_roles
  - [x] user_categories (not currently used but might as well include this)
  - [x] user_measures? (to be confirmed)
  - [x] user_actors? (to be confirmed)