### PR TITLE
Set `relationship_updated_by_id` when relationship changes

### DIFF
--- a/app/models/actor.rb
+++ b/app/models/actor.rb
@@ -21,6 +21,8 @@ class Actor < VersionedRecord
   has_many :user_actors, dependent: :destroy
   has_many :users, through: :user_actors
 
+  belongs_to :relationship_updated_by, class_name: "User", required: false
+
   validates :title, presence: true
   validate :different_parent, :not_own_descendant
 

--- a/app/models/actor_category.rb
+++ b/app/models/actor_category.rb
@@ -9,7 +9,7 @@ class ActorCategory < VersionedRecord
   validates :category_id, presence: true, uniqueness: {scope: :actor_id}
   validate :category_taxonomy_enabled_for_actortype
 
-  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+  after_commit :set_relationship_updated, on: [:create, :update, :destroy]
 
   private
 
@@ -19,7 +19,10 @@ class ActorCategory < VersionedRecord
     end
   end
 
-  def set_relationship_updated_at
-    actor.update_column(:relationship_updated_at, Time.zone.now) if actor && !actor.destroyed?
+  def set_relationship_updated
+    if actor && !actor.destroyed?
+      actor.update_column(:relationship_updated_at, Time.zone.now)
+      actor.update_column(:relationship_updated_by_id, ::PaperTrail.request.whodunnit)
+    end
   end
 end

--- a/app/models/actor_measure.rb
+++ b/app/models/actor_measure.rb
@@ -3,7 +3,7 @@ class ActorMeasure < VersionedRecord
   belongs_to :measure, required: true
 
   validate :actor_actortype_is_active
-  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+  after_commit :set_relationship_updated, on: [:create, :update, :destroy]
 
   private
 
@@ -11,8 +11,15 @@ class ActorMeasure < VersionedRecord
     errors.add(:actor, "actor's actortype is not active") unless actor&.actortype&.is_active
   end
 
-  def set_relationship_updated_at
-    actor.update_column(:relationship_updated_at, Time.zone.now) if actor && !actor.destroyed?
-    measure.update_column(:relationship_updated_at, Time.zone.now) if measure && !measure.destroyed?
+  def set_relationship_updated
+    if actor && !actor.destroyed?
+      actor.update_column(:relationship_updated_at, Time.zone.now)
+      actor.update_column(:relationship_updated_by_id, ::PaperTrail.request.whodunnit)
+    end
+
+    if measure && !measure.destroyed?
+      measure.update_column(:relationship_updated_at, Time.zone.now)
+      measure.update_column(:relationship_updated_by_id, ::PaperTrail.request.whodunnit)
+    end
   end
 end

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -20,6 +20,7 @@ class Indicator < VersionedRecord
   # has_many :direct_recommendations, through: :indicators_recommendations, source: :recommendation
 
   belongs_to :manager, class_name: "User", foreign_key: :manager_id, required: false
+  belongs_to :relationship_updated_by, class_name: "User", required: false
 
   accepts_nested_attributes_for :measure_indicators
 

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -30,6 +30,8 @@ class Measure < VersionedRecord
   belongs_to :measuretype, required: true
   belongs_to :parent, class_name: "Measure", required: false
 
+  belongs_to :relationship_updated_by, class_name: "User", required: false
+
   accepts_nested_attributes_for :recommendation_measures
   accepts_nested_attributes_for :measure_categories
 

--- a/app/models/measure_actor.rb
+++ b/app/models/measure_actor.rb
@@ -4,7 +4,7 @@ class MeasureActor < VersionedRecord
 
   validate :actor_actortype_is_target, :measure_measuretype_has_target
 
-  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+  after_commit :set_relationship_updated, on: [:create, :update, :destroy]
 
   private
 
@@ -16,8 +16,15 @@ class MeasureActor < VersionedRecord
     errors.add(:measure, "measure's measuretype can't have target") unless measure&.measuretype&.has_target
   end
 
-  def set_relationship_updated_at
-    actor.update_column(:relationship_updated_at, Time.zone.now) if actor && !actor.destroyed?
-    measure.update_column(:relationship_updated_at, Time.zone.now) if measure && !measure.destroyed?
+  def set_relationship_updated
+    if actor && !actor.destroyed?
+      actor.update_column(:relationship_updated_at, Time.zone.now)
+      actor.update_column(:relationship_updated_by_id, ::PaperTrail.request.whodunnit)
+    end
+
+    if measure && !measure.destroyed?
+      measure.update_column(:relationship_updated_at, Time.zone.now)
+      measure.update_column(:relationship_updated_by_id, ::PaperTrail.request.whodunnit)
+    end
   end
 end

--- a/app/models/measure_category.rb
+++ b/app/models/measure_category.rb
@@ -10,7 +10,7 @@ class MeasureCategory < VersionedRecord
 
   validate :category_taxonomy_enabled_for_measuretype
 
-  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+  after_commit :set_relationship_updated, on: [:create, :update, :destroy]
 
   private
 
@@ -20,7 +20,10 @@ class MeasureCategory < VersionedRecord
     end
   end
 
-  def set_relationship_updated_at
-    measure.update_column(:relationship_updated_at, Time.zone.now) if measure && !measure.destroyed?
+  def set_relationship_updated
+    if measure && !measure.destroyed?
+      measure.update_column(:relationship_updated_at, Time.zone.now)
+      measure.update_column(:relationship_updated_by_id, ::PaperTrail.request.whodunnit)
+    end
   end
 end

--- a/app/models/measure_indicator.rb
+++ b/app/models/measure_indicator.rb
@@ -8,12 +8,19 @@ class MeasureIndicator < ApplicationRecord
   validates :measure_id, presence: true
   validates :indicator_id, presence: true
 
-  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+  after_commit :set_relationship_updated, on: [:create, :update, :destroy]
 
   private
 
-  def set_relationship_updated_at
-    measure.update_column(:relationship_updated_at, Time.zone.now) if measure && !measure.destroyed?
-    indicator.update_column(:relationship_updated_at, Time.zone.now) if indicator && !indicator.destroyed?
+  def set_relationship_updated
+    if measure && !measure.destroyed?
+      measure.update_column(:relationship_updated_at, Time.zone.now)
+      measure.update_column(:relationship_updated_by_id, ::PaperTrail.request.whodunnit)
+    end
+
+    if indicator && !indicator.destroyed?
+      indicator.update_column(:relationship_updated_at, Time.zone.now)
+      indicator.update_column(:relationship_updated_by_id, ::PaperTrail.request.whodunnit)
+    end
   end
 end

--- a/app/models/measure_measure.rb
+++ b/app/models/measure_measure.rb
@@ -8,7 +8,7 @@ class MeasureMeasure < VersionedRecord
 
   validate :measure_not_other_measure
 
-  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+  after_commit :set_relationship_updated, on: [:create, :update, :destroy]
 
   private
 
@@ -16,8 +16,15 @@ class MeasureMeasure < VersionedRecord
     errors.add(:measure, "can't be the same as other_measure") if measure == other_measure
   end
 
-  def set_relationship_updated_at
-    measure.update_column(:relationship_updated_at, Time.zone.now) if measure && !measure.destroyed?
-    other_measure.update_column(:relationship_updated_at, Time.zone.now) if other_measure && !other_measure.destroyed?
+  def set_relationship_updated
+    if measure && !measure.destroyed?
+      measure.update_column(:relationship_updated_at, Time.zone.now)
+      measure.update_column(:relationship_updated_by_id, ::PaperTrail.request.whodunnit)
+    end
+
+    if other_measure && !other_measure.destroyed?
+      other_measure.update_column(:relationship_updated_at, Time.zone.now)
+      other_measure.update_column(:relationship_updated_by_id, ::PaperTrail.request.whodunnit)
+    end
   end
 end

--- a/app/models/measure_resource.rb
+++ b/app/models/measure_resource.rb
@@ -8,11 +8,14 @@ class MeasureResource < VersionedRecord
   validates :measure_id, presence: true
   validates :resource_id, presence: true, uniqueness: {scope: :measure_id}
 
-  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+  after_commit :set_relationship_updated, on: [:create, :update, :destroy]
 
   private
 
-  def set_relationship_updated_at
-    measure.update_column(:relationship_updated_at, Time.zone.now) if measure && !measure.destroyed?
+  def set_relationship_updated
+    if measure && !measure.destroyed?
+      measure.update_column(:relationship_updated_at, Time.zone.now)
+      measure.update_column(:relationship_updated_by_id, ::PaperTrail.request.whodunnit)
+    end
   end
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -6,7 +6,7 @@ class Membership < VersionedRecord
 
   validate :member_not_memberof
 
-  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+  after_commit :set_relationship_updated, on: [:create, :update, :destroy]
 
   private
 
@@ -14,8 +14,15 @@ class Membership < VersionedRecord
     errors.add(:member, "can't be the same as memberof") if member == memberof
   end
 
-  def set_relationship_updated_at
-    member.update_column(:relationship_updated_at, Time.zone.now) if member && !member.destroyed?
-    memberof.update_column(:relationship_updated_at, Time.zone.now) if memberof && !memberof.destroyed?
+  def set_relationship_updated
+    if member && !member.destroyed?
+      member.update_column(:relationship_updated_at, Time.zone.now)
+      member.update_column(:relationship_updated_by_id, ::PaperTrail.request.whodunnit)
+    end
+
+    if memberof && !memberof.destroyed?
+      memberof.update_column(:relationship_updated_at, Time.zone.now)
+      memberof.update_column(:relationship_updated_by_id, ::PaperTrail.request.whodunnit)
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,8 @@ class User < VersionedRecord
   has_many :user_measures, dependent: :destroy
   has_many :measures, through: :user_measures
 
+  belongs_to :relationship_updated_by, class_name: "User", required: false
+
   validates :email, presence: true
   validates :name, presence: true
 

--- a/app/models/user_actor.rb
+++ b/app/models/user_actor.rb
@@ -6,12 +6,19 @@ class UserActor < VersionedRecord
   validates :user_id, presence: true
   validates :actor_id, presence: true
 
-  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+  after_commit :set_relationship_updated, on: [:create, :update, :destroy]
 
   private
 
-  def set_relationship_updated_at
-    actor.update_column(:relationship_updated_at, Time.zone.now) if actor && !actor.destroyed?
-    user.update_column(:relationship_updated_at, Time.zone.now) if user && !user.destroyed?
+  def set_relationship_updated
+    if actor && !actor.destroyed?
+      actor.update_column(:relationship_updated_at, Time.zone.now)
+      actor.update_column(:relationship_updated_by_id, ::PaperTrail.request.whodunnit)
+    end
+
+    if user && !user.destroyed?
+      user.update_column(:relationship_updated_at, Time.zone.now)
+      user.update_column(:relationship_updated_by_id, ::PaperTrail.request.whodunnit)
+    end
   end
 end

--- a/app/models/user_category.rb
+++ b/app/models/user_category.rb
@@ -6,11 +6,14 @@ class UserCategory < ApplicationRecord
   validates :user_id, presence: true
   validates :category_id, presence: true
 
-  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+  after_commit :set_relationship_updated, on: [:create, :update, :destroy]
 
   private
 
-  def set_relationship_updated_at
-    user.update_column(:relationship_updated_at, Time.zone.now) if user && !user.destroyed?
+  def set_relationship_updated
+    if user && !user.destroyed?
+      user.update_column(:relationship_updated_at, Time.zone.now)
+      user.update_column(:relationship_updated_by_id, ::PaperTrail.request.whodunnit)
+    end
   end
 end

--- a/app/models/user_measure.rb
+++ b/app/models/user_measure.rb
@@ -6,12 +6,19 @@ class UserMeasure < VersionedRecord
   validates :user_id, presence: true
   validates :measure_id, presence: true
 
-  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+  after_commit :set_relationship_updated, on: [:create, :update, :destroy]
 
   private
 
-  def set_relationship_updated_at
-    measure.update_column(:relationship_updated_at, Time.zone.now) if measure && !measure.destroyed?
-    user.update_column(:relationship_updated_at, Time.zone.now) if user && !user.destroyed?
+  def set_relationship_updated
+    if measure && !measure.destroyed?
+      measure.update_column(:relationship_updated_at, Time.zone.now)
+      measure.update_column(:relationship_updated_by_id, ::PaperTrail.request.whodunnit)
+    end
+
+    if user && !user.destroyed?
+      user.update_column(:relationship_updated_at, Time.zone.now)
+      user.update_column(:relationship_updated_by_id, ::PaperTrail.request.whodunnit)
+    end
   end
 end

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -6,11 +6,14 @@ class UserRole < VersionedRecord
 
   delegate :name, to: :role, prefix: true, allow_nil: true
 
-  after_commit :set_relationship_updated_at, on: [:create, :update, :destroy]
+  after_commit :set_relationship_updated, on: [:create, :update, :destroy]
 
   private
 
-  def set_relationship_updated_at
-    user.update_column(:relationship_updated_at, Time.zone.now) if user && !user.destroyed?
+  def set_relationship_updated
+    if user && !user.destroyed?
+      user.update_column(:relationship_updated_at, Time.zone.now)
+      user.update_column(:relationship_updated_by_id, ::PaperTrail.request.whodunnit)
+    end
   end
 end

--- a/app/serializers/actor_serializer.rb
+++ b/app/serializers/actor_serializer.rb
@@ -19,7 +19,8 @@ class ActorSerializer
     :title,
     :url,
     :is_archive,
-    :relationship_updated_at
+    :relationship_updated_at,
+    :relationship_updated_by_id
   )
 
   set_type :actors

--- a/app/serializers/indicator_serializer.rb
+++ b/app/serializers/indicator_serializer.rb
@@ -14,7 +14,8 @@ class IndicatorSerializer
     :end_date,
     :private,
     :is_archive,
-    :relationship_updated_at
+    :relationship_updated_at,
+    :relationship_updated_by_id
   )
 
   set_type :indicators

--- a/app/serializers/measure_serializer.rb
+++ b/app/serializers/measure_serializer.rb
@@ -28,7 +28,8 @@ class MeasureSerializer
     :title,
     :url,
     :is_archive,
-    :relationship_updated_at
+    :relationship_updated_at,
+    :relationship_updated_by_id
   )
 
   set_type :measures

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,7 +1,10 @@
 class UserSerializer
   include FastVersionedSerializer
 
-  attributes :email, :name, :relationship_updated_at
+  attributes :email,
+    :name,
+    :relationship_updated_at,
+    :relationship_updated_by_id
 
   set_type :users
 end

--- a/db/migrate/20220913083216_add_relationship_updated_by_id_to_tables_with_joins.rb
+++ b/db/migrate/20220913083216_add_relationship_updated_by_id_to_tables_with_joins.rb
@@ -1,0 +1,15 @@
+class AddRelationshipUpdatedByIdToTablesWithJoins < ActiveRecord::Migration[6.1]
+  def change
+    add_column :actors, :relationship_updated_by_id, :bigint, null: true
+    add_foreign_key :actors, :users, column: :relationship_updated_by_id, primary_key: :id
+
+    add_column :indicators, :relationship_updated_by_id, :bigint, null: true
+    add_foreign_key :indicators, :users, column: :relationship_updated_by_id, primary_key: :id
+
+    add_column :measures, :relationship_updated_by_id, :bigint, null: true
+    add_foreign_key :measures, :users, column: :relationship_updated_by_id, primary_key: :id
+
+    add_column :users, :relationship_updated_by_id, :bigint, null: true
+    add_foreign_key :users, :users, column: :relationship_updated_by_id, primary_key: :id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_30_085433) do
+ActiveRecord::Schema.define(version: 2022_09_13_083216) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 2022_08_30_085433) do
     t.bigint "parent_id"
     t.boolean "is_archive", default: false
     t.datetime "relationship_updated_at", precision: 6
+    t.bigint "relationship_updated_by_id"
     t.index ["actortype_id"], name: "index_actors_on_actortype_id"
     t.index ["created_by_id"], name: "index_actors_on_created_by_id"
     t.index ["manager_id"], name: "index_actors_on_manager_id"
@@ -189,6 +190,7 @@ ActiveRecord::Schema.define(version: 2022_08_30_085433) do
     t.boolean "is_archive", default: false
     t.string "code"
     t.datetime "relationship_updated_at", precision: 6
+    t.bigint "relationship_updated_by_id"
     t.index ["created_at"], name: "index_indicators_on_created_at"
     t.index ["draft"], name: "index_indicators_on_draft"
     t.index ["manager_id"], name: "index_indicators_on_manager_id"
@@ -291,6 +293,7 @@ ActiveRecord::Schema.define(version: 2022_08_30_085433) do
     t.boolean "is_archive", default: false
     t.boolean "notifications", default: true
     t.datetime "relationship_updated_at", precision: 6
+    t.bigint "relationship_updated_by_id"
     t.index ["draft"], name: "index_measures_on_draft"
     t.index ["measuretype_id"], name: "index_measures_on_measuretype_id"
     t.index ["parent_id"], name: "index_measures_on_parent_id"
@@ -532,6 +535,7 @@ ActiveRecord::Schema.define(version: 2022_08_30_085433) do
     t.boolean "allow_password_change", default: true
     t.integer "created_by_id"
     t.datetime "relationship_updated_at", precision: 6
+    t.bigint "relationship_updated_by_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
@@ -558,12 +562,14 @@ ActiveRecord::Schema.define(version: 2022_08_30_085433) do
   add_foreign_key "actors", "actors", column: "parent_id"
   add_foreign_key "actors", "actortypes"
   add_foreign_key "actors", "users", column: "manager_id"
+  add_foreign_key "actors", "users", column: "relationship_updated_by_id"
   add_foreign_key "actortype_taxonomies", "actortypes"
   add_foreign_key "actortype_taxonomies", "taxonomies"
   add_foreign_key "framework_frameworks", "frameworks"
   add_foreign_key "framework_frameworks", "frameworks", column: "other_framework_id"
   add_foreign_key "framework_taxonomies", "frameworks"
   add_foreign_key "framework_taxonomies", "taxonomies"
+  add_foreign_key "indicators", "users", column: "relationship_updated_by_id"
   add_foreign_key "measure_actors", "actors"
   add_foreign_key "measure_actors", "measures"
   add_foreign_key "measure_actors", "users", column: "created_by_id"
@@ -579,6 +585,7 @@ ActiveRecord::Schema.define(version: 2022_08_30_085433) do
   add_foreign_key "measure_resources", "users", column: "updated_by_id"
   add_foreign_key "measures", "measures", column: "parent_id"
   add_foreign_key "measures", "measuretypes"
+  add_foreign_key "measures", "users", column: "relationship_updated_by_id"
   add_foreign_key "measuretype_taxonomies", "measuretypes"
   add_foreign_key "measuretype_taxonomies", "taxonomies"
   add_foreign_key "memberships", "actors", column: "member_id"
@@ -600,4 +607,5 @@ ActiveRecord::Schema.define(version: 2022_08_30_085433) do
   add_foreign_key "user_measures", "users"
   add_foreign_key "user_measures", "users", column: "created_by_id"
   add_foreign_key "user_measures", "users", column: "updated_by_id"
+  add_foreign_key "users", "users", column: "relationship_updated_by_id"
 end

--- a/spec/models/actor_category_spec.rb
+++ b/spec/models/actor_category_spec.rb
@@ -25,6 +25,9 @@ RSpec.describe ActorCategory, type: :model do
   context "with an actor and a category" do
     let!(:taxonomy) { FactoryBot.create(:actortype_taxonomy, actortype: actor.actortype, taxonomy: category.taxonomy) }
 
+    let(:whodunnit) { FactoryBot.create(:user).id }
+    before { allow(::PaperTrail.request).to receive(:whodunnit).and_return(whodunnit) }
+
     subject { described_class.create(actor: actor, category: category) }
 
     it "create sets the relationship_updated_at on the actor" do
@@ -38,6 +41,20 @@ RSpec.describe ActorCategory, type: :model do
 
     it "destroy sets the relationship_updated_at on the actor" do
       expect { subject.destroy }.to change { actor.reload.relationship_updated_at }
+    end
+
+    it "create sets the relationship_updated_by_id on the actor" do
+      expect { subject }.to change { actor.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "update sets the relationship_updated_by_id on the actor" do
+      subject
+      actor.update_column(:relationship_updated_by_id, nil)
+      expect { subject.touch }.to change { actor.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "destroy sets the relationship_updated_by_id on the actor" do
+      expect { subject.destroy }.to change { actor.reload.relationship_updated_by_id }.to(whodunnit)
     end
   end
 end

--- a/spec/models/actor_measure_spec.rb
+++ b/spec/models/actor_measure_spec.rb
@@ -26,6 +26,9 @@ RSpec.describe ActorMeasure, type: :model do
     let(:actor) { FactoryBot.create(:actor) }
     let(:measure) { FactoryBot.create(:measure) }
 
+    let(:whodunnit) { FactoryBot.create(:user).id }
+    before { allow(::PaperTrail.request).to receive(:whodunnit).and_return(whodunnit) }
+
     subject { described_class.create(actor: actor, measure: measure) }
 
     it "create sets the relationship_updated_at on the actor" do
@@ -52,6 +55,34 @@ RSpec.describe ActorMeasure, type: :model do
 
     it "destroy sets the relationship_updated_at on the measure" do
       expect { subject.destroy }.to change { measure.reload.relationship_updated_at }
+    end
+
+    it "create sets the relationship_updated_by_id on the actor" do
+      expect { subject }.to change { actor.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "create sets the relationship_updated_by_id on the measure" do
+      expect { subject }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "update sets the relationship_updated_by_id on the actor" do
+      subject
+      actor.update_column(:relationship_updated_by_id, nil)
+      expect { subject.touch }.to change { actor.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "update sets the relationship_updated_by_id on the measure" do
+      subject
+      measure.update_column(:relationship_updated_by_id, nil)
+      expect { subject.touch }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "destroy sets the relationship_updated_by_id on the actor" do
+      expect { subject.destroy }.to change { actor.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "destroy sets the relationship_updated_by_id on the measure" do
+      expect { subject.destroy }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
     end
   end
 end

--- a/spec/models/measure_actors_spec.rb
+++ b/spec/models/measure_actors_spec.rb
@@ -44,6 +44,9 @@ RSpec.describe MeasureActor, type: :model do
     let(:actor) { FactoryBot.create(:actor) }
     let(:measure) { FactoryBot.create(:measure) }
 
+    let(:whodunnit) { FactoryBot.create(:user).id }
+    before { allow(::PaperTrail.request).to receive(:whodunnit).and_return(whodunnit) }
+
     subject { described_class.create(actor: actor, measure: measure) }
 
     it "create sets the relationship_updated_at on the actor" do
@@ -70,6 +73,34 @@ RSpec.describe MeasureActor, type: :model do
 
     it "destroy sets the relationship_updated_at on the measure" do
       expect { subject.destroy }.to change { measure.reload.relationship_updated_at }
+    end
+
+    it "create sets the relationship_updated_by_id on the actor" do
+      expect { subject }.to change { actor.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "create sets the relationship_updated_by_id on the measure" do
+      expect { subject }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "update sets the relationship_updated_by_id on the actor" do
+      subject
+      actor.update_column(:relationship_updated_by_id, nil)
+      expect { subject.touch }.to change { actor.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "update sets the relationship_updated_by_id on the measure" do
+      subject
+      measure.update_column(:relationship_updated_by_id, nil)
+      expect { subject.touch }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "destroy sets the relationship_updated_by_id on the actor" do
+      expect { subject.destroy }.to change { actor.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "destroy sets the relationship_updated_by_id on the measure" do
+      expect { subject.destroy }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
     end
   end
 end

--- a/spec/models/measure_category_spec.rb
+++ b/spec/models/measure_category_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe MeasureCategory, type: :model do
   context "when the category's taxonomy is enabled for its measuretype" do
     let!(:measuretype_taxonomy) { FactoryBot.create(:measuretype_taxonomy, measuretype: measure.measuretype, taxonomy: category.taxonomy) }
 
+    let(:whodunnit) { FactoryBot.create(:user).id }
+    before { allow(::PaperTrail.request).to receive(:whodunnit).and_return(whodunnit) }
+
     subject { described_class.create(category: category, measure: measure) }
 
     it "works" do
@@ -36,6 +39,20 @@ RSpec.describe MeasureCategory, type: :model do
 
     it "destroy sets the relationship_updated_at on the measure" do
       expect { subject.destroy }.to change { measure.reload.relationship_updated_at }
+    end
+
+    it "create sets the relationship_updated_by_id on the measure" do
+      expect { subject }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "update sets the relationship_updated_by_id on the measure" do
+      subject
+      measure.update_column(:relationship_updated_by_id, nil)
+      expect { subject.touch }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "destroy sets the relationship_updated_by_id on the measure" do
+      expect { subject.destroy }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
     end
   end
 end

--- a/spec/models/measure_indicator_spec.rb
+++ b/spec/models/measure_indicator_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe MeasureIndicator, type: :model do
     let(:indicator) { FactoryBot.create(:indicator) }
     let(:measure) { FactoryBot.create(:measure) }
 
+    let(:whodunnit) { FactoryBot.create(:user).id }
+    before { allow(::PaperTrail.request).to receive(:whodunnit).and_return(whodunnit) }
+
     subject { described_class.create(indicator: indicator, measure: measure) }
 
     it "create sets the relationship_updated_at on the indicator" do
@@ -35,8 +38,36 @@ RSpec.describe MeasureIndicator, type: :model do
       expect { subject.destroy }.to change { indicator.reload.relationship_updated_at }
     end
 
-    it "destroy sets the relationship_updated_at on the measure" do
-      expect { subject.destroy }.to change { measure.reload.relationship_updated_at }
+    it "destroy sets the relationship_updated_by_id on the measure" do
+      expect { subject.destroy }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "create sets the relationship_updated_by_id on the indicator" do
+      expect { subject }.to change { indicator.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "create sets the relationship_updated_by_id on the measure" do
+      expect { subject }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "update sets the relationship_updated_by_id on the indicator" do
+      subject
+      indicator.update_column(:relationship_updated_by_id, nil)
+      expect { subject.touch }.to change { indicator.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "update sets the relationship_updated_by_id on the measure" do
+      subject
+      measure.update_column(:relationship_updated_by_id, nil)
+      expect { subject.touch }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "destroy sets the relationship_updated_by_id on the indicator" do
+      expect { subject.destroy }.to change { indicator.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "destroy sets the relationship_updated_by_id on the measure" do
+      expect { subject.destroy }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
     end
   end
 end

--- a/spec/models/measure_measure_spec.rb
+++ b/spec/models/measure_measure_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe MeasureMeasure, type: :model do
     let(:other_measure) { FactoryBot.create(:measure) }
     let(:measure) { FactoryBot.create(:measure) }
 
+    let(:whodunnit) { FactoryBot.create(:user).id }
+    before { allow(::PaperTrail.request).to receive(:whodunnit).and_return(whodunnit) }
+
     subject { described_class.create(other_measure: other_measure, measure: measure) }
 
     it "create sets the relationship_updated_at on the other_measure" do
@@ -43,8 +46,36 @@ RSpec.describe MeasureMeasure, type: :model do
       expect { subject.destroy }.to change { other_measure.reload.relationship_updated_at }
     end
 
-    it "destroy sets the relationship_updated_at on the measure" do
-      expect { subject.destroy }.to change { measure.reload.relationship_updated_at }
+    it "destroy sets the relationship_updated_by_id on the measure" do
+      expect { subject.destroy }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "create sets the relationship_updated_by_id on the other_measure" do
+      expect { subject }.to change { other_measure.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "create sets the relationship_updated_by_id on the measure" do
+      expect { subject }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "update sets the relationship_updated_by_id on the other_measure" do
+      subject
+      other_measure.update_column(:relationship_updated_by_id, nil)
+      expect { subject.touch }.to change { other_measure.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "update sets the relationship_updated_by_id on the measure" do
+      subject
+      measure.update_column(:relationship_updated_by_id, nil)
+      expect { subject.touch }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "destroy sets the relationship_updated_by_id on the other_measure" do
+      expect { subject.destroy }.to change { other_measure.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "destroy sets the relationship_updated_by_id on the measure" do
+      expect { subject.destroy }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
     end
   end
 end

--- a/spec/models/measure_resource_spec.rb
+++ b/spec/models/measure_resource_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe MeasureResource, type: :model do
     let(:measure) { FactoryBot.create(:measure) }
     let(:resource) { FactoryBot.create(:resource) }
 
+    let(:whodunnit) { FactoryBot.create(:user).id }
+    before { allow(::PaperTrail.request).to receive(:whodunnit).and_return(whodunnit) }
+
     subject { described_class.create(measure: measure, resource: resource) }
 
     it "create sets the relationship_updated_at on the measure" do
@@ -23,6 +26,20 @@ RSpec.describe MeasureResource, type: :model do
 
     it "destroy sets the relationship_updated_at on the measure" do
       expect { subject.destroy }.to change { measure.reload.relationship_updated_at }
+    end
+
+    it "create sets the relationship_updated_by_id on the measure" do
+      expect { subject }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "update sets the relationship_updated_by_id on the measure" do
+      subject
+      measure.update_column(:relationship_updated_by_id, nil)
+      expect { subject.touch }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "destroy sets the relationship_updated_by_id on the measure" do
+      expect { subject.destroy }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
     end
   end
 end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe Membership, type: :model do
   end
 
   context "with a member and a memberof" do
+    let(:whodunnit) { FactoryBot.create(:user).id }
+    before { allow(::PaperTrail.request).to receive(:whodunnit).and_return(whodunnit) }
+
     subject { described_class.create(member: member, memberof: memberof) }
 
     it "create sets the relationship_updated_at on the member" do
@@ -45,6 +48,34 @@ RSpec.describe Membership, type: :model do
 
     it "destroy sets the relationship_updated_at on the memberof" do
       expect { subject.destroy }.to change { memberof.reload.relationship_updated_at }
+    end
+
+    it "create sets the relationship_updated_by_id on the member" do
+      expect { subject }.to change { member.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "create sets the relationship_updated_by_id on the memberof" do
+      expect { subject }.to change { memberof.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "update sets the relationship_updated_by_id on the member" do
+      subject
+      member.update_column(:relationship_updated_by_id, nil)
+      expect { subject.touch }.to change { member.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "update sets the relationship_updated_by_id on the memberof" do
+      subject
+      memberof.update_column(:relationship_updated_by_id, nil)
+      expect { subject.touch }.to change { memberof.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "destroy sets the relationship_updated_by_id on the member" do
+      expect { subject.destroy }.to change { member.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "destroy sets the relationship_updated_by_id on the memberof" do
+      expect { subject.destroy }.to change { memberof.reload.relationship_updated_by_id }.to(whodunnit)
     end
   end
 end

--- a/spec/models/user_actor_spec.rb
+++ b/spec/models/user_actor_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe UserActor, type: :model do
     let(:actor) { FactoryBot.create(:actor) }
     let(:user) { FactoryBot.create(:user) }
 
+    let(:whodunnit) { FactoryBot.create(:user).id }
+    before { allow(::PaperTrail.request).to receive(:whodunnit).and_return(whodunnit) }
+
     subject { described_class.create(actor: actor, user: user) }
 
     it "create sets the relationship_updated_at on the actor" do
@@ -38,6 +41,34 @@ RSpec.describe UserActor, type: :model do
 
     it "destroy sets the relationship_updated_at on the user" do
       expect { subject.destroy }.to change { user.reload.relationship_updated_at }
+    end
+
+    it "create sets the relationship_updated_by_id on the actor" do
+      expect { subject }.to change { actor.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "create sets the relationship_updated_by_id on the user" do
+      expect { subject }.to change { user.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "update sets the relationship_updated_by_id on the actor" do
+      subject
+      actor.update_column(:relationship_updated_by_id, nil)
+      expect { subject.touch }.to change { actor.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "update sets the relationship_updated_by_id on the user" do
+      subject
+      user.update_column(:relationship_updated_by_id, nil)
+      expect { subject.touch }.to change { user.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "destroy sets the relationship_updated_by_id on the actor" do
+      expect { subject.destroy }.to change { actor.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "destroy sets the relationship_updated_by_id on the user" do
+      expect { subject.destroy }.to change { user.reload.relationship_updated_by_id }.to(whodunnit)
     end
   end
 end

--- a/spec/models/user_category_spec.rb
+++ b/spec/models/user_category_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe UserCategory, type: :model do
     let(:user) { FactoryBot.create(:user) }
     let(:category) { FactoryBot.create(:category) }
 
+    let(:whodunnit) { FactoryBot.create(:user).id }
+    before { allow(::PaperTrail.request).to receive(:whodunnit).and_return(whodunnit) }
+
     subject { described_class.create(user: user, category: category) }
 
     it "create sets the relationship_updated_at on the user" do
@@ -24,6 +27,20 @@ RSpec.describe UserCategory, type: :model do
 
     it "destroy sets the relationship_updated_at on the user" do
       expect { subject.destroy }.to change { user.reload.relationship_updated_at }
+    end
+
+    it "create sets the relationship_updated_by_id on the user" do
+      expect { subject }.to change { user.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "update sets the relationship_updated_by_id on the user" do
+      subject
+      user.update_column(:relationship_updated_by_id, nil)
+      expect { subject.touch }.to change { user.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "destroy sets the relationship_updated_by_id on the user" do
+      expect { subject.destroy }.to change { user.reload.relationship_updated_by_id }.to(whodunnit)
     end
   end
 end

--- a/spec/models/user_measure_spec.rb
+++ b/spec/models/user_measure_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe UserMeasure, type: :model do
     let(:user) { FactoryBot.create(:user) }
     let(:measure) { FactoryBot.create(:measure) }
 
+    let(:whodunnit) { FactoryBot.create(:user).id }
+    before { allow(::PaperTrail.request).to receive(:whodunnit).and_return(whodunnit) }
+
     subject { described_class.create(user: user, measure: measure) }
 
     it "create sets the relationship_updated_at on the user" do
@@ -38,6 +41,34 @@ RSpec.describe UserMeasure, type: :model do
 
     it "destroy sets the relationship_updated_at on the measure" do
       expect { subject.destroy }.to change { measure.reload.relationship_updated_at }
+    end
+
+    it "create sets the relationship_updated_by_id on the user" do
+      expect { subject }.to change { user.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "create sets the relationship_updated_by_id on the measure" do
+      expect { subject }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "update sets the relationship_updated_by_id on the user" do
+      subject
+      user.update_column(:relationship_updated_by_id, nil)
+      expect { subject.touch }.to change { user.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "update sets the relationship_updated_by_id on the measure" do
+      subject
+      measure.update_column(:relationship_updated_by_id, nil)
+      expect { subject.touch }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "destroy sets the relationship_updated_by_id on the user" do
+      expect { subject.destroy }.to change { user.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "destroy sets the relationship_updated_by_id on the measure" do
+      expect { subject.destroy }.to change { measure.reload.relationship_updated_by_id }.to(whodunnit)
     end
   end
 end

--- a/spec/models/user_role_spec.rb
+++ b/spec/models/user_role_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe UserRole, type: :model do
     let(:user) { FactoryBot.create(:user) }
     let(:role) { FactoryBot.create(:role) }
 
+    let(:whodunnit) { FactoryBot.create(:user).id }
+    before { allow(::PaperTrail.request).to receive(:whodunnit).and_return(whodunnit) }
+
     subject { described_class.create(user: user, role: role) }
 
     it "create sets the relationship_updated_at on the user" do
@@ -22,6 +25,20 @@ RSpec.describe UserRole, type: :model do
 
     it "destroy sets the relationship_updated_at on the user" do
       expect { subject.destroy }.to change { user.reload.relationship_updated_at }
+    end
+
+    it "create sets the relationship_updated_by_id on the user" do
+      expect { subject }.to change { user.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "update sets the relationship_updated_by_id on the user" do
+      subject
+      user.update_column(:relationship_updated_by_id, nil)
+      expect { subject.touch }.to change { user.reload.relationship_updated_by_id }.to(whodunnit)
+    end
+
+    it "destroy sets the relationship_updated_by_id on the user" do
+      expect { subject.destroy }.to change { user.reload.relationship_updated_by_id }.to(whodunnit)
     end
   end
 end


### PR DESCRIPTION
Fixes #46

Earlier we added tracking for `relationship_updated_at` in #53 and we decided
to track who updated it as well using a new field `relationship_updated_by_id`.