### PR TITLE
Remove feature testing support including poltergeist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,6 @@ group :test do
   gem "connection_pool"
   gem "database_cleaner"
   gem "launchy"
-  gem "poltergeist"
   gem "pry-rails"
   gem "shoulda-matchers"
   gem "timecop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,6 @@ GEM
     case_transform (0.2)
       activesupport
     childprocess (4.1.0)
-    cliver (0.3.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     connection_pool (2.2.5)
@@ -227,10 +226,6 @@ GEM
     parser (3.0.2.0)
       ast (~> 2.4.1)
     pg (1.2.3)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -425,7 +420,6 @@ DEPENDENCIES
   overcommit
   paper_trail
   pg (~> 1.2)
-  poltergeist
   pry-rails
   puma (~> 5.5)
   pundit

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ The IMPACT OSS project is maintained by the Impact Open Source Software Trust. T
 This project requires:
 
 * Ruby 3.0.2, preferably managed using [rbenv][]
-* PhantomJS (in order to use the [poltergeist][] gem)
 * PostgreSQL must be installed and accepting connections
 
 On a Mac, you can obtain all of the above packages using [Homebrew][]. If you wish to use Docker, the above dependencies will be provided by the Dockerfile and docker-compose file included in this repository.
@@ -116,7 +115,6 @@ Run the `bin/setup` script. This script will:
 2. Run `rails s` to start the Rails app.
 
 [rbenv]:https://github.com/sstephenson/rbenv
-[poltergeist]:https://github.com/teampoltergeist/poltergeist
 [Homebrew]:http://brew.sh
 
 ---

--- a/spec/features/indicator_spec.rb
+++ b/spec/features/indicator_spec.rb
@@ -1,4 +1,0 @@
-require "rails_helper"
-
-RSpec.feature "Indicators", type: :feature do
-end

--- a/spec/features/measure_spec.rb
+++ b/spec/features/measure_spec.rb
@@ -1,4 +1,0 @@
-require "rails_helper"
-
-RSpec.feature "User can see measures views", type: :feature do
-end

--- a/spec/features/recommendation_spec.rb
+++ b/spec/features/recommendation_spec.rb
@@ -1,4 +1,0 @@
-require "rails_helper"
-
-RSpec.feature "User can see recommendation views", type: :feature do
-end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,11 +1,4 @@
 # frozen_string_literal: true
 
-# Capybara + poltergeist allow JS testing via headless webkit
 require "capybara/rails"
-require "capybara/poltergeist"
 require "capybara/rspec"
-Capybara.javascript_driver = :poltergeist
-
-RSpec.configure do |config|
-  config.include Capybara::DSL, type: :feature
-end


### PR DESCRIPTION
I noticed that we were depending on Poltergeist but not using it.

Luckily, it's really quick and easy to remove it including all of the
empty feature test files.