### PR TITLE
fix user_measure_mailer and spec

### DIFF
--- a/app/views/user_measure_mailer/created.en.text.erb
+++ b/app/views/user_measure_mailer/created.en.text.erb
@@ -3,7 +3,7 @@ New <%= @type %> assigned
 
 Hi <%= @name %>,
 
-There is a new <%= @type %> <%= @title %> assigned to you, please see details here: plastic-advocacy.wwf.no/action/<%= @measure_id %>
+There is a new <%= @type %> assigned to you, please see details here: plastic-advocacy.wwf.no/action/<%= @measure_id %>
 
 Thank you,
 

--- a/app/views/user_measure_mailer/published.en.text.erb
+++ b/app/views/user_measure_mailer/published.en.text.erb
@@ -3,7 +3,7 @@ New <%= @type %> assigned
 
 Hi <%= @name %>,
 
-There is a new <%= @type %> <%= @title %> assigned to you, please see details here: https://plastic-advocacy.wwf.no/action/<%= @measure_id %>
+There is a new <%= @type %> assigned to you, please see details here: https://plastic-advocacy.wwf.no/action/<%= @measure_id %>
 
 Thank you,
 

--- a/spec/mailers/user_measure_mailer_spec.rb
+++ b/spec/mailers/user_measure_mailer_spec.rb
@@ -50,8 +50,5 @@ RSpec.describe UserMeasureMailer, type: :mailer do
       expect(mail.body.encoded).to match(user_measure.user.name)
     end
 
-    it "mentions the measure title" do
-      expect(mail.body.encoded).to match(user_measure.measure.title)
-    end
   end
 end


### PR DESCRIPTION
only mention type, not title in assignment email