### PR TITLE
Send task updated notifications when tasks are updated or created for other users

### DIFF
--- a/app/jobs/task_notification_job.rb
+++ b/app/jobs/task_notification_job.rb
@@ -1,9 +1,9 @@
 class TaskNotificationJob
   include Sidekiq::Worker
 
-  def perform(user_measure_id)
-    user_measure = UserMeasure.find(user_measure_id)
-    return unless user_measure&.notify?
+  def perform(user_id, measure_id)
+    user_measure = UserMeasure.find_by(user_id: user_id, measure_id: measure_id)
+    return if !user_measure || !user_measure.notify?
 
     UserMeasureMailer.task_updated(user_measure).deliver_now
   end

--- a/spec/controllers/measures_controller_spec.rb
+++ b/spec/controllers/measures_controller_spec.rb
@@ -391,7 +391,7 @@ RSpec.describe MeasuresController, type: :controller do
             let(:measure) { FactoryBot.create(:measure, :published, notifications: true) }
 
             it "notifies the user of an update to #{attr}" do
-              expect(TaskNotificationJob).to receive(:perform_in).with(ENV.fetch("TASK_NOTIFICATION_DELAY", 20).to_i.seconds, user_measure.id)
+              expect(TaskNotificationJob).to receive(:perform_in).with(ENV.fetch("TASK_NOTIFICATION_DELAY", 20).to_i.seconds, user_measure.user_id, user_measure.measure_id)
 
               put :update, format: :json, params: {id: measure, measure: {attr => "test"}}
             end
@@ -418,7 +418,7 @@ RSpec.describe MeasuresController, type: :controller do
 
             context "and is updated to not archived" do
               it "does notify the user of an update to #{attr}" do
-                expect(TaskNotificationJob).to receive(:perform_in).with(ENV.fetch("TASK_NOTIFICATION_DELAY", 20).to_i.seconds, user_measure.id)
+                expect(TaskNotificationJob).to receive(:perform_in).with(ENV.fetch("TASK_NOTIFICATION_DELAY", 20).to_i.seconds, user_measure.user_id, user_measure.measure_id)
 
                 put :update, format: :json, params: {id: measure, measure: {attr => "test", :is_archive => false}}
               end

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Measure, type: :model do
         let(:user_id) { FactoryBot.create(:user).id }
 
         it "will queue notifications when relationship_updated_at changes" do
-          expect(TaskNotificationJob).to receive(:perform_in).with(ENV.fetch("TASK_NOTIFICATION_DELAY", 20).to_i.seconds, user_measure.id)
+          expect(TaskNotificationJob).to receive(:perform_in).with(ENV.fetch("TASK_NOTIFICATION_DELAY", 20).to_i.seconds, user_measure.user_id, user_measure.measure_id)
 
           subject.touch(:relationship_updated_at)
         end


### PR DESCRIPTION
Previously, whenever we assign a user to a (published) measure...

- The `UserMeasuresController` triggers the "created" notification
  calling `UserMeasureMailer.created`.
- The `UserMeasure` model updated the measure's
  `relationship_updated_at` attribute.
- Which triggered the `updated` notification via the
  `TaskNotificationJob`.

This was resulting in a duplicate notification for the user was just
assigned to the task because they would get one saying there is a new
task assigned to them *and* one saying that a task they are assigned
to has been updated.

After this change the assigned user will only get the single email
saying that a task has been assigned to them.
